### PR TITLE
feat(platform): Compose Postgres for staging & prod + profile wiring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ IMAGE    := mythictales/$(APP_NAME):latest
 PORT     := 8080
 JAVA_OPTS ?=
 
-.PHONY: help run build test package clean format check-format docker-build docker-run docker-stop docker-rm spotbugs spotbugs-strict setup-commit-template
+.PHONY: help run build test package clean format check-format docker-build docker-run docker-stop docker-rm spotbugs spotbugs-strict setup-commit-template db-up-staging db-stop-staging db-up-prod db-stop-prod
 
 help:
 	@echo "Targets:"
@@ -24,6 +24,10 @@ help:
 	@echo "  docker-rm     - Remove stopped container"
 	@echo "  spotbugs      - Generate SpotBugs report (non-fatal)"
 	@echo "  spotbugs-strict - Fail on HIGH severity SpotBugs issues"
+	@echo "  db-up-staging - Start Postgres (staging) via compose"
+	@echo "  db-stop-staging - Stop Postgres (staging)"
+	@echo "  db-up-prod    - Start Postgres (prod) via compose"
+	@echo "  db-stop-prod  - Stop Postgres (prod)"
 	@echo "  setup-commit-template - Configure git commit.template to .gitmessage.txt"
 
 run:
@@ -64,6 +68,23 @@ spotbugs:
 
 spotbugs-strict:
 	mvn -B -ntp -Dspotbugs.failOnError=true -Dspotbugs.threshold=High spotbugs:check
+
+# Docker Compose helpers for Postgres
+db-up-staging:
+	@[ -f .env ] || (echo "Missing .env. Copy .env.example to .env and set passwords." && exit 1)
+	docker compose --profile staging up -d postgres-staging
+
+db-stop-staging:
+	docker compose stop postgres-staging || true
+	docker compose rm -f postgres-staging || true
+
+db-up-prod:
+	@[ -f .env ] || (echo "Missing .env. Copy .env.example to .env and set passwords." && exit 1)
+	docker compose --profile prod up -d postgres-prod
+
+db-stop-prod:
+	docker compose stop postgres-prod || true
+	docker compose rm -f postgres-prod || true
 
 setup-commit-template:
 	git config commit.template .gitmessage.txt

--- a/README.md
+++ b/README.md
@@ -6,6 +6,73 @@
 
 A Spring Boot 3 application for managing brewery taplists and related admin workflows. Includes Thymeleaf pages for admins and a REST API scaffold documented with Swagger.
 
+## Docker Compose — Postgres (Staging & Prod)
+
+This repo includes a Compose file that runs two separate Postgres containers for staging and production.
+
+Quick start:
+
+1) Copy the example env and set strong passwords:
+
+```
+cp .env.example .env
+# edit .env to set passwords and ports as desired
+```
+
+2) Start staging or production database:
+
+```
+# Staging DB on localhost:5433
+make db-up-staging
+
+# Production DB on localhost:5432
+make db-up-prod
+```
+
+3) Stop containers when done:
+
+```
+make db-stop-staging
+make db-stop-prod
+```
+
+Connection strings (examples):
+
+```
+# Staging
+jdbc:postgresql://localhost:${STAGING_POSTGRES_PORT:-5433}/${STAGING_POSTGRES_DB}
+user: ${STAGING_POSTGRES_USER}
+password: ${STAGING_POSTGRES_PASSWORD}
+
+# Production
+jdbc:postgresql://localhost:${PRODUCTION_POSTGRES_PORT:-5432}/${PRODUCTION_POSTGRES_DB}
+user: ${PRODUCTION_POSTGRES_USER}
+password: ${PRODUCTION_POSTGRES_PASSWORD}
+```
+
+Compose file: `compose.yaml`. Variables are sourced from `.env`.
+
+## Spring Profiles — Staging & Production
+
+Profiles are pre-wired to use the Compose Postgres instances:
+
+- `staging`: connects to `localhost:5433` (DB `${STAGING_POSTGRES_DB}`)
+- `prod`: connects to `localhost:5432` (DB `${PRODUCTION_POSTGRES_DB}`)
+
+Run the app with a profile:
+
+```
+# Staging
+SPRING_PROFILES_ACTIVE=staging mvn spring-boot:run
+
+# Production
+SPRING_PROFILES_ACTIVE=prod mvn spring-boot:run
+```
+
+Notes:
+- Staging uses `ddl-auto=validate` and keeps Swagger UI enabled.
+- Production uses `ddl-auto=none` and disables Swagger UI and H2 console.
+
 ## Quick Start
 
 - Prerequisites: Java 17+, Maven 3.9+

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,55 @@
+services:
+  postgres-staging:
+    image: postgres:16-alpine
+    container_name: bms-postgres-staging
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      - POSTGRES_DB=${STAGING_POSTGRES_DB}
+      - POSTGRES_USER=${STAGING_POSTGRES_USER}
+      - POSTGRES_PASSWORD=${STAGING_POSTGRES_PASSWORD}
+    ports:
+      - "${STAGING_POSTGRES_PORT:-5433}:5432"
+    volumes:
+      - pgdata-staging:/var/lib/postgresql/data
+    networks:
+      - bms-net
+    profiles: ["staging"]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${STAGING_POSTGRES_USER} -d ${STAGING_POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  postgres-prod:
+    image: postgres:16-alpine
+    container_name: bms-postgres-prod
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      - POSTGRES_DB=${PRODUCTION_POSTGRES_DB}
+      - POSTGRES_USER=${PRODUCTION_POSTGRES_USER}
+      - POSTGRES_PASSWORD=${PRODUCTION_POSTGRES_PASSWORD}
+    ports:
+      - "${PRODUCTION_POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - pgdata-prod:/var/lib/postgresql/data
+    networks:
+      - bms-net
+    profiles: ["prod"]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${PRODUCTION_POSTGRES_USER} -d ${PRODUCTION_POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  pgdata-staging:
+  pgdata-prod:
+
+networks:
+  bms-net:
+    driver: bridge
+

--- a/docs/tech/reviewbranches/20250916-compose-postgres-staging-prod.md
+++ b/docs/tech/reviewbranches/20250916-compose-postgres-staging-prod.md
@@ -1,0 +1,21 @@
+# feature/platform/compose-postgres-staging-prod
+
+- Area: platform
+- Owner: genie-platform-data
+- Task: docs/techtasks/101-genie-platform-data-tasks.md (Sprint 3 — Postgres enablement)
+- Summary: Add Docker Compose for Postgres (staging & prod) and wire Spring profiles
+- Scope: compose.yaml, .env.example, Makefile, README, application-staging.yml, application-prod.yml, pom.xml (Postgres driver)
+- Risk: low (dev-only infra; isolated volumes; no schema change)
+- Test Plan:
+  - Copy `.env.example` to `.env` and set strong passwords
+  - `make db-up-staging` and `make db-up-prod` bring containers up healthy
+  - `SPRING_PROFILES_ACTIVE=staging mvn spring-boot:run` connects to staging DB
+  - `SPRING_PROFILES_ACTIVE=prod mvn spring-boot:run` connects to prod DB
+  - Verify Flyway runs and app boots
+- Status: in-progress
+- PR: <tbd>
+
+## Notes
+- Uses Compose profiles to isolate staging (`5433`) and prod (`5432`).
+- Healthchecks via `pg_isready`; data persisted in separate volumes.
+- Swagger UI enabled in staging, disabled in prod; H2 console disabled for both.

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
       <groupId>org.flywaydb</groupId>
       <artifactId>flyway-core</artifactId>
     </dependency>
+    <!-- Postgres JDBC driver -->
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
     <!-- Mockito: rely on mockito-core via spring-boot-starter-test.
          Subclass mock-maker is configured under src/test/resources. -->
   </dependencies>

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:${PRODUCTION_POSTGRES_PORT:5432}/${PRODUCTION_POSTGRES_DB:mythic_prod}
+    username: ${PRODUCTION_POSTGRES_USER:bms}
+    password: ${PRODUCTION_POSTGRES_PASSWORD:changeme-prod}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: none
+    show-sql: false
+  flyway:
+    enabled: true
+  h2:
+    console:
+      enabled: false
+
+springdoc:
+  swagger-ui:
+    enabled: false
+

--- a/src/main/resources/application-staging.yml
+++ b/src/main/resources/application-staging.yml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:${STAGING_POSTGRES_PORT:5433}/${STAGING_POSTGRES_DB:mythic_staging}
+    username: ${STAGING_POSTGRES_USER:bms}
+    password: ${STAGING_POSTGRES_PASSWORD:changeme-staging}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+  flyway:
+    enabled: true
+  h2:
+    console:
+      enabled: false
+
+springdoc:
+  swagger-ui:
+    enabled: true
+


### PR DESCRIPTION
This PR adds Docker Compose with separate Postgres services for staging and production and wires Spring profiles to use them.

Summary
- Compose services: `postgres-staging` (5433) and `postgres-prod` (5432) using profiles
- `.env.example` with variables for DB/user/password/port
- Makefile helpers: `db-up-staging`, `db-stop-staging`, `db-up-prod`, `db-stop-prod`
- Spring profiles: `application-staging.yml` and `application-prod.yml`
- Postgres JDBC driver added (runtime)
- README updated with usage and profile instructions

Risk
- Low; dev/staging infra only. Separate volumes for staging/prod containers.

Validation
- `mvn -q -DskipTests package` passes
- `make db-up-staging` and `make db-up-prod` start healthy Postgres containers
- Application connects under staging and prod profiles

References
- docs/techtasks/101-genie-platform-data-tasks.md (Sprint 3 — Postgres enablement)
- Review entry: docs/tech/reviewbranches/20250916-compose-postgres-staging-prod.md
