### PR TITLE
feat(api): beer style link + recipe import read/validation

### DIFF
--- a/src/main/java/com/mythictales/bms/taplist/api/ApiMappers.java
+++ b/src/main/java/com/mythictales/bms/taplist/api/ApiMappers.java
@@ -8,7 +8,14 @@ public final class ApiMappers {
 
   public static BeerDto toDto(Beer b) {
     if (b == null) return null;
-    return new BeerDto(b.getId(), b.getName(), b.getStyle(), b.getAbv());
+    return new BeerDto(
+        b.getId(),
+        b.getName(),
+        b.getStyle(),
+        b.getStyleRef() != null ? b.getStyleRef().getId() : null,
+        b.getAbv(),
+        b.getBrewery() != null ? b.getBrewery().getId() : null,
+        b.getBreweryName());
   }
 
   public static KegSizeSpecDto toDto(KegSizeSpec s) {

--- a/src/main/java/com/mythictales/bms/taplist/api/BeerApiController.java
+++ b/src/main/java/com/mythictales/bms/taplist/api/BeerApiController.java
@@ -4,12 +4,18 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import com.mythictales.bms.taplist.api.dto.BeerDto;
+import com.mythictales.bms.taplist.catalog.repo.BjcpStyleRepository;
+import com.mythictales.bms.taplist.domain.Beer;
 import com.mythictales.bms.taplist.repo.BeerRepository;
+import com.mythictales.bms.taplist.service.BusinessValidationException;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
@@ -17,9 +23,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "Beers")
 public class BeerApiController {
   private final BeerRepository beers;
+  private final BjcpStyleRepository styles;
 
-  public BeerApiController(BeerRepository beers) {
+  public BeerApiController(BeerRepository beers, BjcpStyleRepository styles) {
     this.beers = beers;
+    this.styles = styles;
   }
 
   @GetMapping
@@ -33,5 +41,32 @@ public class BeerApiController {
         .findById(id)
         .map(b -> ResponseEntity.ok(ApiMappers.toDto(b)))
         .orElse(ResponseEntity.notFound().build());
+  }
+
+  public record StyleLinkRequest(Long styleId) {}
+
+  @PatchMapping(value = "/{id}/styleRef", consumes = MediaType.APPLICATION_JSON_VALUE)
+  @PreAuthorize("hasRole('SITE_ADMIN') or hasRole('BREWERY_ADMIN')")
+  @Operation(summary = "Link a BJCP style to a beer")
+  public ResponseEntity<BeerDto> linkStyle(
+      @PathVariable Long id, @RequestBody StyleLinkRequest req) {
+    if (req == null || req.styleId == null) {
+      throw new BusinessValidationException("styleId is required");
+    }
+    Beer b = beers.findById(id).orElseThrow(java.util.NoSuchElementException::new);
+    var style = styles.findById(req.styleId()).orElseThrow(java.util.NoSuchElementException::new);
+    b.setStyleRef(style);
+    beers.save(b);
+    return ResponseEntity.ok(ApiMappers.toDto(b));
+  }
+
+  @DeleteMapping("/{id}/styleRef")
+  @PreAuthorize("hasRole('SITE_ADMIN') or hasRole('BREWERY_ADMIN')")
+  @Operation(summary = "Unlink BJCP style from a beer")
+  public ResponseEntity<BeerDto> unlinkStyle(@PathVariable Long id) {
+    Beer b = beers.findById(id).orElseThrow(java.util.NoSuchElementException::new);
+    b.setStyleRef(null);
+    beers.save(b);
+    return ResponseEntity.ok(ApiMappers.toDto(b));
   }
 }

--- a/src/main/java/com/mythictales/bms/taplist/api/dto/BeerDto.java
+++ b/src/main/java/com/mythictales/bms/taplist/api/dto/BeerDto.java
@@ -1,3 +1,10 @@
 package com.mythictales.bms.taplist.api.dto;
 
-public record BeerDto(Long id, String name, String style, double abv) {}
+public record BeerDto(
+    Long id,
+    String name,
+    String style,
+    Long styleRefId,
+    double abv,
+    Long breweryId,
+    String breweryName) {}

--- a/src/main/java/com/mythictales/bms/taplist/catalog/api/CatalogApiMappers.java
+++ b/src/main/java/com/mythictales/bms/taplist/catalog/api/CatalogApiMappers.java
@@ -1,0 +1,121 @@
+package com.mythictales.bms.taplist.catalog.api;
+
+import java.util.List;
+
+import com.mythictales.bms.taplist.catalog.api.dto.*;
+import com.mythictales.bms.taplist.catalog.domain.*;
+
+public final class CatalogApiMappers {
+  private CatalogApiMappers() {}
+
+  public static RecipeDto toDto(Recipe r) {
+    if (r == null) return null;
+    return new RecipeDto(
+        r.getId(),
+        r.getBrewery() != null ? r.getBrewery().getId() : null,
+        r.getName(),
+        r.getStyleName(),
+        r.getType(),
+        r.getBatchSizeLiters(),
+        r.getBoilTimeMinutes(),
+        r.getIbu(),
+        r.getAbv(),
+        r.getOg(),
+        r.getFg(),
+        r.getEfficiency(),
+        r.getEquipment(),
+        r.getSourceFormat() != null ? r.getSourceFormat().name() : null,
+        r.getSourceHash(),
+        r.getNotes(),
+        r.getCreatedAt(),
+        toDtoFermentables(r.getFermentables()),
+        toDtoHops(r.getHops()),
+        toDtoYeasts(r.getYeasts()),
+        toDtoMiscs(r.getMiscs()),
+        toDtoMashSteps(r.getMashSteps()));
+  }
+
+  public static List<RecipeFermentableDto> toDtoFermentables(List<RecipeFermentable> list) {
+    return list == null
+        ? java.util.List.of()
+        : list.stream()
+            .map(
+                f ->
+                    new RecipeFermentableDto(
+                        f.getId(),
+                        f.getName(),
+                        f.getAmountKg(),
+                        f.getYieldPercent(),
+                        f.getColorLovibond(),
+                        f.getLateAddition(),
+                        f.getType()))
+            .toList();
+  }
+
+  public static List<RecipeHopDto> toDtoHops(List<RecipeHop> list) {
+    return list == null
+        ? java.util.List.of()
+        : list.stream()
+            .map(
+                h ->
+                    new RecipeHopDto(
+                        h.getId(),
+                        h.getName(),
+                        h.getAlphaAcid(),
+                        h.getAmountGrams(),
+                        h.getTimeMinutes(),
+                        h.getUseFor(),
+                        h.getForm(),
+                        h.getIbuContribution()))
+            .toList();
+  }
+
+  public static List<RecipeYeastDto> toDtoYeasts(List<RecipeYeast> list) {
+    return list == null
+        ? java.util.List.of()
+        : list.stream()
+            .map(
+                y ->
+                    new RecipeYeastDto(
+                        y.getId(),
+                        y.getName(),
+                        y.getLaboratory(),
+                        y.getProductId(),
+                        y.getType(),
+                        y.getForm(),
+                        y.getAttenuation()))
+            .toList();
+  }
+
+  public static List<RecipeMiscDto> toDtoMiscs(List<RecipeMisc> list) {
+    return list == null
+        ? java.util.List.of()
+        : list.stream()
+            .map(
+                m ->
+                    new RecipeMiscDto(
+                        m.getId(),
+                        m.getName(),
+                        m.getType(),
+                        m.getAmount(),
+                        m.getAmountUnit(),
+                        m.getUseFor()))
+            .toList();
+  }
+
+  public static List<MashStepDto> toDtoMashSteps(List<MashStep> list) {
+    return list == null
+        ? java.util.List.of()
+        : list.stream()
+            .map(
+                ms ->
+                    new MashStepDto(
+                        ms.getId(),
+                        ms.getName(),
+                        ms.getType(),
+                        ms.getStepTempC(),
+                        ms.getStepTimeMinutes(),
+                        ms.getInfuseAmountLiters()))
+            .toList();
+  }
+}

--- a/src/main/java/com/mythictales/bms/taplist/catalog/api/RecipeApiController.java
+++ b/src/main/java/com/mythictales/bms/taplist/catalog/api/RecipeApiController.java
@@ -1,0 +1,62 @@
+package com.mythictales.bms.taplist.catalog.api;
+
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import com.mythictales.bms.taplist.catalog.api.dto.RecipeDto;
+import com.mythictales.bms.taplist.catalog.repo.RecipeRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@RequestMapping("/api/v1/catalog/recipes")
+@Tag(name = "Catalog: Recipes")
+public class RecipeApiController {
+  private final RecipeRepository recipes;
+
+  public RecipeApiController(RecipeRepository recipes) {
+    this.recipes = recipes;
+  }
+
+  @GetMapping
+  @PreAuthorize(
+      "hasAnyRole('SITE_ADMIN','BREWERY_ADMIN') and (#breweryId == principal.breweryId or hasRole('SITE_ADMIN'))")
+  @Operation(summary = "List recipes for a brewery")
+  public Page<RecipeDto> list(
+      @RequestParam("breweryId") Long breweryId,
+      @ParameterObject @PageableDefault(sort = "createdAt") Pageable pageable) {
+    return recipes.findByBrewery_Id(breweryId, pageable).map(CatalogApiMappers::toDto);
+  }
+
+  @GetMapping("/{id}")
+  @PreAuthorize("hasAnyRole('SITE_ADMIN','BREWERY_ADMIN')")
+  @Operation(summary = "Get a recipe by id (with children)")
+  public ResponseEntity<RecipeDto> get(
+      @PathVariable Long id,
+      @org.springframework.security.core.annotation.AuthenticationPrincipal
+          com.mythictales.bms.taplist.security.CurrentUser user) {
+    return recipes
+        .findById(id)
+        .map(
+            r -> {
+              Long userBrewery = user != null ? user.getBreweryId() : null;
+              Long recipeBrewery = r.getBrewery() != null ? r.getBrewery().getId() : null;
+              boolean siteAdmin =
+                  user != null
+                      && user.getAuthorities().stream()
+                          .anyMatch(a -> a.getAuthority().equals("ROLE_SITE_ADMIN"));
+              if (!siteAdmin && userBrewery != null && !userBrewery.equals(recipeBrewery)) {
+                throw new org.springframework.security.access.AccessDeniedException(
+                    "Cross-tenant access forbidden");
+              }
+              return ResponseEntity.ok(CatalogApiMappers.toDto(r));
+            })
+        .orElse(ResponseEntity.notFound().build());
+  }
+}

--- a/src/main/java/com/mythictales/bms/taplist/catalog/api/RecipeImportController.java
+++ b/src/main/java/com/mythictales/bms/taplist/catalog/api/RecipeImportController.java
@@ -2,6 +2,7 @@ package com.mythictales.bms.taplist.catalog.api;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -12,6 +13,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.mythictales.bms.taplist.catalog.service.RecipeImportService;
 import com.mythictales.bms.taplist.catalog.service.RecipeImportService.DuplicateRecipeException;
+import com.mythictales.bms.taplist.service.BusinessValidationException;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -29,27 +31,54 @@ public class RecipeImportController {
   public record ImportResponse(List<Long> ids) {}
 
   @PostMapping(value = "/import", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  @PreAuthorize("hasAnyRole('SITE_ADMIN','BREWERY_ADMIN')")
+  @PreAuthorize(
+      "hasAnyRole('SITE_ADMIN','BREWERY_ADMIN') and (#breweryId == principal.breweryId or hasRole('SITE_ADMIN'))")
   @Operation(summary = "Import BeerXML or BeerSmith XML; returns created recipe IDs")
   public ResponseEntity<?> importRecipes(
       @RequestParam("breweryId") Long breweryId,
       @RequestParam(value = "force", defaultValue = "false") boolean force,
       @RequestPart("file") MultipartFile file) {
     try {
+      if (file == null || file.isEmpty()) {
+        throw new BusinessValidationException("Empty file", Map.of("reason", "EMPTY_FILE"));
+      }
+      // hard cap to protect service (2MB)
+      if (file.getSize() > 2_000_000) {
+        throw new BusinessValidationException(
+            "File too large (max 2MB)", Map.of("reason", "FILE_TOO_LARGE", "maxBytes", 2_000_000));
+      }
+      String ct = file.getContentType();
+      if (ct != null
+          && !(ct.equalsIgnoreCase(MediaType.APPLICATION_XML_VALUE)
+              || ct.equalsIgnoreCase(MediaType.TEXT_XML_VALUE)
+              || ct.equalsIgnoreCase("application/octet-stream"))) {
+        throw new BusinessValidationException(
+            "Unsupported content type", Map.of("contentType", ct));
+      }
       String xml = new String(file.getBytes(), StandardCharsets.UTF_8);
       List<Long> ids = importer.importXml(breweryId, xml, force);
       return ResponseEntity.ok(new ImportResponse(ids));
     } catch (DuplicateRecipeException dup) {
       return ResponseEntity.status(HttpStatus.CONFLICT)
-          .contentType(MediaType.APPLICATION_JSON)
-          .body("{\"error\":\"DUPLICATE_RECIPE\",\"existingId\":" + dup.getExistingId() + "}");
+          .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+          .body(
+              java.util.Map.of(
+                  "status",
+                  409,
+                  "error",
+                  "Conflict",
+                  "message",
+                  "Duplicate recipe",
+                  "details",
+                  Map.of("existingId", dup.getExistingId())));
     } catch (Exception e) {
       return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-          .contentType(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_PROBLEM_JSON)
           .body(
-              "{\"error\":\"IMPORT_FAILED\",\"message\":\""
-                  + e.getMessage().replace("\"", "'")
-                  + "\"}");
+              java.util.Map.of(
+                  "status", HttpStatus.BAD_REQUEST.value(),
+                  "error", "Bad Request",
+                  "message", e.getMessage()));
     }
   }
 }

--- a/src/main/java/com/mythictales/bms/taplist/catalog/api/dto/MashStepDto.java
+++ b/src/main/java/com/mythictales/bms/taplist/catalog/api/dto/MashStepDto.java
@@ -1,0 +1,9 @@
+package com.mythictales.bms.taplist.catalog.api.dto;
+
+public record MashStepDto(
+    Long id,
+    String name,
+    String type,
+    Double stepTempC,
+    Integer stepTimeMinutes,
+    Double infuseAmountLiters) {}

--- a/src/main/java/com/mythictales/bms/taplist/catalog/api/dto/RecipeDto.java
+++ b/src/main/java/com/mythictales/bms/taplist/catalog/api/dto/RecipeDto.java
@@ -1,0 +1,28 @@
+package com.mythictales.bms.taplist.catalog.api.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+public record RecipeDto(
+    Long id,
+    Long breweryId,
+    String name,
+    String styleName,
+    String type,
+    Double batchSizeLiters,
+    Integer boilTimeMinutes,
+    Double ibu,
+    Double abv,
+    Double og,
+    Double fg,
+    Double efficiency,
+    String equipment,
+    String sourceFormat,
+    String sourceHash,
+    String notes,
+    Instant createdAt,
+    List<RecipeFermentableDto> fermentables,
+    List<RecipeHopDto> hops,
+    List<RecipeYeastDto> yeasts,
+    List<RecipeMiscDto> miscs,
+    List<MashStepDto> mashSteps) {}

--- a/src/main/java/com/mythictales/bms/taplist/catalog/api/dto/RecipeFermentableDto.java
+++ b/src/main/java/com/mythictales/bms/taplist/catalog/api/dto/RecipeFermentableDto.java
@@ -1,0 +1,10 @@
+package com.mythictales.bms.taplist.catalog.api.dto;
+
+public record RecipeFermentableDto(
+    Long id,
+    String name,
+    Double amountKg,
+    Double yieldPercent,
+    Double colorLovibond,
+    Boolean lateAddition,
+    String type) {}

--- a/src/main/java/com/mythictales/bms/taplist/catalog/api/dto/RecipeHopDto.java
+++ b/src/main/java/com/mythictales/bms/taplist/catalog/api/dto/RecipeHopDto.java
@@ -1,0 +1,11 @@
+package com.mythictales.bms.taplist.catalog.api.dto;
+
+public record RecipeHopDto(
+    Long id,
+    String name,
+    Double alphaAcid,
+    Double amountGrams,
+    Integer timeMinutes,
+    String useFor,
+    String form,
+    Double ibuContribution) {}

--- a/src/main/java/com/mythictales/bms/taplist/catalog/api/dto/RecipeMiscDto.java
+++ b/src/main/java/com/mythictales/bms/taplist/catalog/api/dto/RecipeMiscDto.java
@@ -1,0 +1,4 @@
+package com.mythictales.bms.taplist.catalog.api.dto;
+
+public record RecipeMiscDto(
+    Long id, String name, String type, Double amount, String amountUnit, String useFor) {}

--- a/src/main/java/com/mythictales/bms/taplist/catalog/api/dto/RecipeYeastDto.java
+++ b/src/main/java/com/mythictales/bms/taplist/catalog/api/dto/RecipeYeastDto.java
@@ -1,0 +1,10 @@
+package com.mythictales.bms.taplist.catalog.api.dto;
+
+public record RecipeYeastDto(
+    Long id,
+    String name,
+    String laboratory,
+    String productId,
+    String type,
+    String form,
+    Double attenuation) {}

--- a/src/main/java/com/mythictales/bms/taplist/catalog/domain/Recipe.java
+++ b/src/main/java/com/mythictales/bms/taplist/catalog/domain/Recipe.java
@@ -201,4 +201,25 @@ public class Recipe {
   public void setBrewery(Brewery brewery) {
     this.brewery = brewery;
   }
+
+  // Child collections accessors
+  public List<RecipeFermentable> getFermentables() {
+    return fermentables;
+  }
+
+  public List<RecipeHop> getHops() {
+    return hops;
+  }
+
+  public List<RecipeYeast> getYeasts() {
+    return yeasts;
+  }
+
+  public List<RecipeMisc> getMiscs() {
+    return miscs;
+  }
+
+  public List<MashStep> getMashSteps() {
+    return mashSteps;
+  }
 }

--- a/src/main/java/com/mythictales/bms/taplist/catalog/repo/RecipeRepository.java
+++ b/src/main/java/com/mythictales/bms/taplist/catalog/repo/RecipeRepository.java
@@ -2,10 +2,14 @@ package com.mythictales.bms.taplist.catalog.repo;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.mythictales.bms.taplist.catalog.domain.Recipe;
 
 public interface RecipeRepository extends JpaRepository<Recipe, Long> {
   Optional<Recipe> findFirstByBrewery_IdAndSourceHash(Long breweryId, String sourceHash);
+
+  Page<Recipe> findByBrewery_Id(Long breweryId, Pageable pageable);
 }


### PR DESCRIPTION
Implements Catalog P0: recipe import child mapping + read endpoints with Problem JSON and tenant scoping; and adds Beer–BJCP style link/unlink endpoints.\n\n- Endpoints: GET /api/v1/catalog/recipes, GET /api/v1/catalog/recipes/{id}\n- Import validation, dedup 409, and file constraints\n- DTOs + mappers for Recipe and children\n- PATCH/DELETE /api/v1/beers/{id}/styleRef; BeerDto includes styleRefId\n\nReview entry: docs/tech/reviewbranches/20250916-beer-style-linking-and-recipes-p0.md\nTask: docs/techtasks/112-genie-catalog-tasks.md