### PR TITLE
fix(mvc): simplify Thymeleaf badge rendering in brewery kegs/assigned…

### DIFF
--- a/src/main/resources/templates/admin/brewery.html
+++ b/src/main/resources/templates/admin/brewery.html
@@ -89,13 +89,19 @@
         <td th:text="${k.beer.name}">Beer</td>
         <td th:text="${k.size}">HALF_BARREL</td>
         <td>
-          <span class="badge" th:text="${k.status}"
-                th:classappend="${(k.status == T(com.mythictales.bms.taplist.domain.KegStatus).FILLED) ? ' green' :
-                                (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).DISTRIBUTED ? ' blue' :
-                                (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).RECEIVED ? ' purple' :
-                                (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).TAPPED ? ' orange' :
-                                (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).BLOWN ? ' red' : ' gray'))))}">
-          </span>
+          <th:block th:switch="${k.status}">
+            <span class="badge green" th:case="${T(com.mythictales.bms.taplist.domain.KegStatus).FILLED}"
+                  th:text="${k.status}"></span>
+            <span class="badge blue" th:case="${T(com.mythictales.bms.taplist.domain.KegStatus).DISTRIBUTED}"
+                  th:text="${k.status}"></span>
+            <span class="badge purple" th:case="${T(com.mythictales.bms.taplist.domain.KegStatus).RECEIVED}"
+                  th:text="${k.status}"></span>
+            <span class="badge orange" th:case="${T(com.mythictales.bms.taplist.domain.KegStatus).TAPPED}"
+                  th:text="${k.status}"></span>
+            <span class="badge red" th:case="${T(com.mythictales.bms.taplist.domain.KegStatus).BLOWN}"
+                  th:text="${k.status}"></span>
+            <span class="badge gray" th:case="*" th:text="${k.status}"></span>
+          </th:block>
         </td>
         <td th:text="${k.assignedVenue != null ? k.assignedVenue.name : '-'}">-</td>
         <td>
@@ -182,13 +188,19 @@
           <td th:text="${k.beer.name}">Beer</td>
           <td th:text="${k.size}">SIXTEL</td>
           <td>
-            <span class="badge" th:text="${k.status}"
-                  th:classappend="${(k.status == T(com.mythictales.bms.taplist.domain.KegStatus).FILLED) ? ' green' :
-                                  (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).DISTRIBUTED ? ' blue' :
-                                  (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).RECEIVED ? ' purple' :
-                                  (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).TAPPED ? ' orange' :
-                                  (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).BLOWN ? ' red' : ' gray'))))}">
-            </span>
+            <th:block th:switch="${k.status}">
+              <span class="badge green" th:case="${T(com.mythictales.bms.taplist.domain.KegStatus).FILLED}"
+                    th:text="${k.status}"></span>
+              <span class="badge blue" th:case="${T(com.mythictales.bms.taplist.domain.KegStatus).DISTRIBUTED}"
+                    th:text="${k.status}"></span>
+              <span class="badge purple" th:case="${T(com.mythictales.bms.taplist.domain.KegStatus).RECEIVED}"
+                    th:text="${k.status}"></span>
+              <span class="badge orange" th:case="${T(com.mythictales.bms.taplist.domain.KegStatus).TAPPED}"
+                    th:text="${k.status}"></span>
+              <span class="badge red" th:case="${T(com.mythictales.bms.taplist.domain.KegStatus).BLOWN}"
+                    th:text="${k.status}"></span>
+              <span class="badge gray" th:case="*" th:text="${k.status}"></span>
+            </th:block>
           </td>
           <td th:text="${k.assignedVenue != null ? k.assignedVenue.name : '-'}">-</td>
           <td>


### PR DESCRIPTION
… sections to avoid parser issues in staging

- Replace nested ternary th:classappend with th:switch blocks per status
- Keeps visual styling identical and reduces expression complexity
- Verified locally via tests; should address template parsing error in staging

Refs: PR #7

## Summary

Describe the change and why it’s needed. Link to the branch entry in `docs/tech/reviewbranches`.

Branch entry: <!-- e.g., docs/tech/reviewbranches/20250914-feature-api-pour-validation-422.md -->

## Scope of changes

- Areas: <!-- api | platform | both -->
- Key paths touched:

## Validation

- [ ] Built locally (`mvn verify`)
- [ ] SpotBugs high-severity clean
- [ ] Swagger UI loads (`/swagger-ui.html`)
- [ ] Manual test steps and results:

## Risks & Rollback Plan

Call out known risks and how to revert safely.

