### PR TITLE
feat(api): enforce tenant scope on beer style link/unlink; tests for …

### DIFF
--- a/docs/catalog/recipes-editor.md
+++ b/docs/catalog/recipes-editor.md
@@ -1,0 +1,38 @@
+# Catalog — Recipe Editor (Admin)
+
+Overview
+- Navigate to Admin → Brewery → Catalog tab to access recipe tools.
+- Use “Import Recipe” to upload BeerXML or BeerSmith XML files.
+- Click “Edit Recipe” to open the editor. You can update core fields and manage ingredients and mash steps.
+
+Editing
+- Core: name, style name, type, batch size (L), boil time (min), notes.
+- Ingredients:
+  - Fermentables: name, amount (kg), yield %, color (Lovibond), late addition, type.
+  - Hops: name, alpha %, amount (g), time (min), use, form, IBU contribution.
+  - Yeasts: name, lab, product id, type, form, attenuation.
+  - Misc: name, type, amount + unit, use.
+  - Mash Steps: name, type, step temp (°C), step time (min), infuse amount (L).
+
+Export
+- From the edit page, export the recipe in either format:
+  - Export BeerXML → downloads BeerXML 1.0
+  - Export BeerSmith XML → downloads BeerSmith-style XML
+
+Security & Scope
+- Only SITE_ADMIN or BREWERY_ADMIN can import, edit, or export.
+- BREWERY_ADMIN actions are restricted to their own brewery’s recipes.
+
+API Reference
+- List recipes: `GET /api/v1/catalog/recipes?breweryId={id}` (paged)
+- Recipe detail: `GET /api/v1/catalog/recipes/{id}`
+- Import: `POST /api/v1/catalog/recipes/import` (multipart)
+  - Constraints: non-empty file, <= 2MB; duplicate detection with 409 on `force=false`.
+- Style link (beer): `PATCH /api/v1/beers/{id}/styleRef` with `{ "styleId": <long> }`
+- Unlink style: `DELETE /api/v1/beers/{id}/styleRef`
+
+Problem JSON
+- Errors return `application/problem+json` with fields: `status`, `error`, `message`, `details`, `timestamp`.
+
+Notes
+- Child-level editing is basic; future enhancements can add inline editing and reordering.

--- a/src/test/java/com/mythictales/bms/taplist/catalog/api/RecipeImportControllerTest.java
+++ b/src/test/java/com/mythictales/bms/taplist/catalog/api/RecipeImportControllerTest.java
@@ -1,0 +1,82 @@
+package com.mythictales.bms.taplist.catalog.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.mythictales.bms.taplist.catalog.service.RecipeImportService;
+
+/** Tests validation and responses for RecipeImportController. */
+public class RecipeImportControllerTest {
+  private RecipeImportService service;
+  private MockMvc mvc;
+
+  @BeforeEach
+  void setup() {
+    service = Mockito.mock(RecipeImportService.class);
+    mvc =
+        MockMvcBuilders.standaloneSetup(new RecipeImportController(service))
+            .setControllerAdvice(new com.mythictales.bms.taplist.config.RestExceptionHandler())
+            .alwaysDo(org.springframework.test.web.servlet.result.MockMvcResultHandlers.print())
+            .build();
+  }
+
+  @Test
+  void emptyFile_returns400() throws Exception {
+    MockMultipartFile f = new MockMultipartFile("file", new byte[0]);
+    mvc.perform(
+            multipart("/api/v1/catalog/recipes/import")
+                .file(f)
+                .param("breweryId", "9")
+                .param("force", "false")
+                .contentType(MediaType.MULTIPART_FORM_DATA))
+        .andExpect(status().isBadRequest())
+        .andExpect(content().contentType("application/problem+json"));
+  }
+
+  @Test
+  void ok_returnsIds() throws Exception {
+    when(service.importXml(eq(9L), any(String.class), eq(false))).thenReturn(List.of(1L, 2L));
+    MockMultipartFile f =
+        new MockMultipartFile(
+            "file", "r.xml", "application/xml", "<RECIPES></RECIPES>".getBytes(StandardCharsets.UTF_8));
+    mvc.perform(
+            multipart("/api/v1/catalog/recipes/import")
+                .file(f)
+                .param("breweryId", "9")
+                .param("force", "false")
+                .contentType(MediaType.MULTIPART_FORM_DATA))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.ids").isArray());
+  }
+
+  @Test
+  void duplicate_returns409() throws Exception {
+    when(service.importXml(eq(9L), any(String.class), eq(false)))
+        .thenThrow(new RecipeImportService.DuplicateRecipeException(99L));
+    MockMultipartFile f =
+        new MockMultipartFile(
+            "file", "r.xml", "application/xml", "<RECIPES><RECIPE/></RECIPES>".getBytes(StandardCharsets.UTF_8));
+    mvc.perform(
+            multipart("/api/v1/catalog/recipes/import")
+                .file(f)
+                .param("breweryId", "9")
+                .param("force", "false")
+                .contentType(MediaType.MULTIPART_FORM_DATA))
+        .andExpect(status().isConflict())
+        .andExpect(content().contentType("application/problem+json"));
+  }
+}
+


### PR DESCRIPTION
…import; docs for recipe editor\n\n- Beer API: tenant checks using @AuthenticationPrincipal CurrentUser\n- Tests: RecipeImportController validation + duplicate/ok paths\n- Docs: Catalog recipe editor guide (admin)

## Summary

Describe the change and why it’s needed. Link to the branch entry in `docs/tech/reviewbranches`.

Branch entry: <!-- e.g., docs/tech/reviewbranches/20250914-feature-api-pour-validation-422.md -->

## Scope of changes

- Areas: <!-- api | platform | both -->
- Key paths touched:

## Validation

- [ ] Built locally (`mvn verify`)
- [ ] SpotBugs high-severity clean
- [ ] Swagger UI loads (`/swagger-ui.html`)
- [ ] Manual test steps and results:

## Risks & Rollback Plan

Call out known risks and how to revert safely.

