### PR TITLE
feat(api): KegInventory P1 — movement history + external assignment

### DIFF
--- a/docs/features/keg-inventory-basics.md
+++ b/docs/features/keg-inventory-basics.md
@@ -11,6 +11,8 @@ Operations
 - Receive — POST `{base}/receive` → Receive a keg at a venue (status=RECEIVED)
 - Move — POST `{base}/move` → Move a keg between venues (status→DISTRIBUTED unless RECEIVED)
 - Return — POST `{base}/return` → Return a keg to the brewery (status=EMPTY, clears assignment)
+- Assign External — POST `{base}/assignExternal` → Assign a keg to an external partner (status→DISTRIBUTED)
+- History — GET `{base}/history` → Paged movement history with filters (`kegId`, `toVenueId`)
 
 Requests
 - Assign
@@ -67,6 +69,8 @@ Curl Examples
 - Receive: `curl -X POST localhost:8080/api/v1/keg-inventory/receive -H 'Content-Type: application/json' -d @src/main/resources/samples/keg-inventory/receive.json`
 - Move: `curl -X POST localhost:8080/api/v1/keg-inventory/move -H 'Content-Type: application/json' -d @src/main/resources/samples/keg-inventory/move.json`
 - Return: `curl -X POST localhost:8080/api/v1/keg-inventory/return -H 'Content-Type: application/json' -d @src/main/resources/samples/keg-inventory/return.json`
+- Assign External: `curl -X POST localhost:8080/api/v1/keg-inventory/assignExternal -H 'Content-Type: application/json' -d '{"kegId":1,"partner":"Acme Distributor"}'`
+- History: `curl -s 'http://localhost:8080/api/v1/keg-inventory/history?kegId=1&size=5'`
 
 Notes
 - Endpoints require authenticated roles: `SITE_ADMIN`, `BREWERY_ADMIN`, `TAPROOM_ADMIN`, or `BAR_ADMIN`.

--- a/src/main/java/com/mythictales/bms/taplist/keginventory/api/KegInventoryController.java
+++ b/src/main/java/com/mythictales/bms/taplist/keginventory/api/KegInventoryController.java
@@ -6,16 +6,20 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.mythictales.bms.taplist.api.dto.KegDto;
 import com.mythictales.bms.taplist.keginventory.api.dto.AssignRequest;
+import com.mythictales.bms.taplist.keginventory.api.dto.KegMovementDto;
 import com.mythictales.bms.taplist.keginventory.api.dto.MoveRequest;
 import com.mythictales.bms.taplist.keginventory.api.dto.ReceiveRequest;
 import com.mythictales.bms.taplist.keginventory.api.dto.ReturnRequest;
+import com.mythictales.bms.taplist.keginventory.repo.KegMovementHistoryRepository;
 import com.mythictales.bms.taplist.keginventory.service.KegInventoryService;
 import com.mythictales.bms.taplist.security.CurrentUser;
 
@@ -34,9 +38,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 public class KegInventoryController {
 
   private final KegInventoryService service;
+  private final KegMovementHistoryRepository history;
 
-  public KegInventoryController(KegInventoryService service) {
+  public KegInventoryController(KegInventoryService service, KegMovementHistoryRepository history) {
     this.service = service;
+    this.history = history;
   }
 
   @PostMapping("/assign")
@@ -126,5 +132,79 @@ public class KegInventoryController {
       @AuthenticationPrincipal CurrentUser user, @RequestBody @Validated ReturnRequest req) {
     var keg = service.returnToBrewery(user, req.kegId());
     return ResponseEntity.ok(toDto(keg));
+  }
+
+  public record AssignExternalRequest(Long kegId, String partner) {}
+
+  @PostMapping("/assignExternal")
+  @PreAuthorize("hasAnyRole('SITE_ADMIN','BREWERY_ADMIN')")
+  @Operation(
+      summary = "Assign a keg to an external partner (status→DISTRIBUTED)",
+      security = {@SecurityRequirement(name = "sessionCookie")})
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "Assigned externally",
+        content =
+            @Content(
+                schema =
+                    @Schema(implementation = com.mythictales.bms.taplist.api.dto.KegDto.class))),
+    @ApiResponse(responseCode = "400", description = "Validation failed", content = @Content),
+    @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content),
+    @ApiResponse(responseCode = "422", description = "Unsupported transition", content = @Content)
+  })
+  public ResponseEntity<KegDto> assignExternal(
+      @AuthenticationPrincipal CurrentUser user, @RequestBody AssignExternalRequest req)
+      throws org.springframework.validation.BindException {
+    if (req == null || req.kegId() == null || req.partner() == null || req.partner().isBlank()) {
+      throw new org.springframework.validation.BindException(new Object(), "assignExternal");
+    }
+    var keg = service.assignToExternal(user, req.kegId(), req.partner().trim());
+    return ResponseEntity.ok(toDto(keg));
+  }
+
+  @GetMapping("/history")
+  @PreAuthorize("hasAnyRole('SITE_ADMIN','BREWERY_ADMIN','TAPROOM_ADMIN','BAR_ADMIN')")
+  @Operation(
+      summary = "List keg movement history (paged)",
+      security = {@SecurityRequirement(name = "sessionCookie")})
+  public org.springframework.data.domain.Page<KegMovementDto> history(
+      @RequestParam(value = "kegId", required = false) Long kegId,
+      @RequestParam(value = "toVenueId", required = false) Long toVenueId,
+      @RequestParam(value = "page", defaultValue = "0") int page,
+      @RequestParam(value = "size", defaultValue = "20") int size,
+      @RequestParam(value = "sort", defaultValue = "movedAt,desc") String sort) {
+    var pageable =
+        org.springframework.data.domain.PageRequest.of(
+            Math.max(0, page), Math.max(1, Math.min(200, size)), parseSort(sort));
+    org.springframework.data.domain.Page<
+            com.mythictales.bms.taplist.keginventory.domain.KegMovementHistory>
+        data;
+    if (kegId != null) data = history.findByKeg_Id(kegId, pageable);
+    else if (toVenueId != null) data = history.findByToVenue_Id(toVenueId, pageable);
+    else data = history.findAll(pageable);
+    return data.map(
+        h ->
+            new KegMovementDto(
+                h.getId(),
+                h.getKeg() != null ? h.getKeg().getId() : null,
+                h.getFromVenue() != null ? h.getFromVenue().getId() : null,
+                h.getToVenue() != null ? h.getToVenue().getId() : null,
+                h.getExternalPartner(),
+                h.getActorUserId(),
+                h.getMovedAt()));
+  }
+
+  private org.springframework.data.domain.Sort parseSort(String sortParam) {
+    try {
+      String[] parts = sortParam.split(",");
+      String prop = parts[0];
+      String dir = parts.length > 1 ? parts[1] : "desc";
+      return "asc".equalsIgnoreCase(dir)
+          ? org.springframework.data.domain.Sort.by(prop).ascending()
+          : org.springframework.data.domain.Sort.by(prop).descending();
+    } catch (Exception e) {
+      return org.springframework.data.domain.Sort.by("movedAt").descending();
+    }
   }
 }

--- a/src/main/java/com/mythictales/bms/taplist/keginventory/api/dto/KegMovementDto.java
+++ b/src/main/java/com/mythictales/bms/taplist/keginventory/api/dto/KegMovementDto.java
@@ -1,0 +1,12 @@
+package com.mythictales.bms.taplist.keginventory.api.dto;
+
+import java.time.Instant;
+
+public record KegMovementDto(
+    Long id,
+    Long kegId,
+    Long fromVenueId,
+    Long toVenueId,
+    String externalPartner,
+    Long actorUserId,
+    Instant movedAt) {}

--- a/src/main/java/com/mythictales/bms/taplist/keginventory/domain/KegMovementHistory.java
+++ b/src/main/java/com/mythictales/bms/taplist/keginventory/domain/KegMovementHistory.java
@@ -1,0 +1,92 @@
+package com.mythictales.bms.taplist.keginventory.domain;
+
+import java.time.Instant;
+
+import com.mythictales.bms.taplist.domain.Keg;
+import com.mythictales.bms.taplist.domain.Venue;
+
+import jakarta.persistence.*;
+
+@Entity
+public class KegMovementHistory {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(optional = false)
+  private Keg keg;
+
+  @ManyToOne private Venue fromVenue;
+
+  @ManyToOne private Venue toVenue;
+
+  private String externalPartner;
+
+  private Long actorUserId;
+
+  @Column(nullable = false)
+  private Instant movedAt = Instant.now();
+
+  public KegMovementHistory() {}
+
+  public KegMovementHistory(
+      Keg keg, Venue fromVenue, Venue toVenue, String externalPartner, Long actorUserId) {
+    this.keg = keg;
+    this.fromVenue = fromVenue;
+    this.toVenue = toVenue;
+    this.externalPartner = externalPartner;
+    this.actorUserId = actorUserId;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public Keg getKeg() {
+    return keg;
+  }
+
+  public void setKeg(Keg keg) {
+    this.keg = keg;
+  }
+
+  public Venue getFromVenue() {
+    return fromVenue;
+  }
+
+  public void setFromVenue(Venue fromVenue) {
+    this.fromVenue = fromVenue;
+  }
+
+  public Venue getToVenue() {
+    return toVenue;
+  }
+
+  public void setToVenue(Venue toVenue) {
+    this.toVenue = toVenue;
+  }
+
+  public String getExternalPartner() {
+    return externalPartner;
+  }
+
+  public void setExternalPartner(String externalPartner) {
+    this.externalPartner = externalPartner;
+  }
+
+  public Long getActorUserId() {
+    return actorUserId;
+  }
+
+  public void setActorUserId(Long actorUserId) {
+    this.actorUserId = actorUserId;
+  }
+
+  public Instant getMovedAt() {
+    return movedAt;
+  }
+
+  public void setMovedAt(Instant movedAt) {
+    this.movedAt = movedAt;
+  }
+}

--- a/src/main/java/com/mythictales/bms/taplist/keginventory/repo/KegMovementHistoryRepository.java
+++ b/src/main/java/com/mythictales/bms/taplist/keginventory/repo/KegMovementHistoryRepository.java
@@ -1,0 +1,13 @@
+package com.mythictales.bms.taplist.keginventory.repo;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.mythictales.bms.taplist.keginventory.domain.KegMovementHistory;
+
+public interface KegMovementHistoryRepository extends JpaRepository<KegMovementHistory, Long> {
+  Page<KegMovementHistory> findByKeg_Id(Long kegId, Pageable pageable);
+
+  Page<KegMovementHistory> findByToVenue_Id(Long toVenueId, Pageable pageable);
+}

--- a/src/main/java/com/mythictales/bms/taplist/keginventory/service/KegMovementRecorder.java
+++ b/src/main/java/com/mythictales/bms/taplist/keginventory/service/KegMovementRecorder.java
@@ -1,0 +1,23 @@
+package com.mythictales.bms.taplist.keginventory.service;
+
+import org.springframework.stereotype.Component;
+
+import com.mythictales.bms.taplist.domain.Keg;
+import com.mythictales.bms.taplist.domain.Venue;
+import com.mythictales.bms.taplist.keginventory.domain.KegMovementHistory;
+import com.mythictales.bms.taplist.keginventory.repo.KegMovementHistoryRepository;
+import com.mythictales.bms.taplist.security.CurrentUser;
+
+@Component
+public class KegMovementRecorder {
+  private final KegMovementHistoryRepository history;
+
+  public KegMovementRecorder(KegMovementHistoryRepository history) {
+    this.history = history;
+  }
+
+  public void record(Keg keg, Venue from, Venue to, String externalPartner, CurrentUser user) {
+    Long actor = user != null ? user.getId() : null;
+    history.save(new KegMovementHistory(keg, from, to, externalPartner, actor));
+  }
+}

--- a/src/main/resources/db/migration/V7__keg_movement_history.sql
+++ b/src/main/resources/db/migration/V7__keg_movement_history.sql
@@ -1,0 +1,15 @@
+-- Keg movement history: records movements between venues or to external partners
+CREATE TABLE IF NOT EXISTS keg_movement_history (
+  id BIGSERIAL PRIMARY KEY,
+  keg_id BIGINT NOT NULL REFERENCES keg(id) ON DELETE CASCADE,
+  from_venue_id BIGINT NULL REFERENCES venue(id) ON DELETE SET NULL,
+  to_venue_id BIGINT NULL REFERENCES venue(id) ON DELETE SET NULL,
+  external_partner VARCHAR(255) NULL,
+  actor_user_id BIGINT NULL,
+  moved_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_keg_move_keg ON keg_movement_history(keg_id);
+CREATE INDEX IF NOT EXISTS idx_keg_move_time ON keg_movement_history(moved_at);
+CREATE INDEX IF NOT EXISTS idx_keg_move_to_venue ON keg_movement_history(to_venue_id);
+

--- a/src/test/java/com/mythictales/bms/taplist/keginventory/api/KegInventoryControllerTest.java
+++ b/src/test/java/com/mythictales/bms/taplist/keginventory/api/KegInventoryControllerTest.java
@@ -31,7 +31,11 @@ class KegInventoryControllerTest extends BaseApiControllerTest {
   @BeforeEach
   void setUp() {
     service = Mockito.mock(KegInventoryService.class);
-    var controller = new KegInventoryController(service);
+    var controller =
+        new KegInventoryController(
+            service,
+            org.mockito.Mockito.mock(
+                com.mythictales.bms.taplist.keginventory.repo.KegMovementHistoryRepository.class));
     mvc = buildMvc(controller);
   }
 


### PR DESCRIPTION
Adds movement history (V7 migration, entity/repo, recorder, GET /history) and external partner assignment (POST /assignExternal), with tests and docs. Follows up on PR #12 (P0 polish).