### PR TITLE
docs(api): BJCP styles OpenAPI examples; recipes import docs

### DIFF
--- a/docs/catalog/recipes-import.md
+++ b/docs/catalog/recipes-import.md
@@ -73,15 +73,51 @@ Mash Steps → `mash_step`
   - Dedup via `source_hash`; returns 409 Conflict Problem JSON if duplicate and `force=false`
   - Persists `Recipe` + children; returns created ids: `{ "ids": [1,2,...] }`
 
+### Examples
+
+Import a BeerXML file (breweryId 9):
+
+```
+curl -X POST "http://localhost:8080/api/v1/catalog/recipes/import" \
+  -H "Authorization: Bearer <token>" \
+  -F breweryId=9 \
+  -F force=false \
+  -F file=@/path/to/recipe.xml;type=application/xml
+```
+
+Duplicate (force=false) response (409):
+
+```
+{
+  "status": 409,
+  "error": "Conflict",
+  "message": "Duplicate recipe",
+  "details": { "existingId": 123 },
+  "timestamp": "2025-09-17T12:34:56Z"
+}
+```
+
 ## Read API
 - `GET /api/v1/catalog/recipes?breweryId={id}&page=&size=&sort=`
   - Paged recipes for a brewery; tenant‑scoped
 - `GET /api/v1/catalog/recipes/{id}`
   - Returns a `Recipe` with child components; tenant‑scoped
 
+### Examples
+
+List recipes (page 0, size 20):
+
+```
+curl "http://localhost:8080/api/v1/catalog/recipes?breweryId=9&page=0&size=20&sort=createdAt,desc"
+```
+
 ## Idempotency & Dedup
 - Importers compute `source_hash` from normalized XML (trimmed, comments removed) to detect duplicates.
 - If a duplicate is detected and `force=false`, responds 409 Conflict (Problem JSON) with `details.existingId`.
+
+## Swagger
+- Swagger UI: http://localhost:8080/swagger-ui.html
+- OpenAPI JSON: http://localhost:8080/v3/api-docs
 
 ## Future Enhancements
 - Profiles as first‑class: style/equipment/mash profiles normalized into separate tables

--- a/src/main/java/com/mythictales/bms/taplist/catalog/api/BjcpStyleController.java
+++ b/src/main/java/com/mythictales/bms/taplist/catalog/api/BjcpStyleController.java
@@ -14,6 +14,10 @@ import com.mythictales.bms.taplist.catalog.repo.BjcpStyleRepository;
 import com.mythictales.bms.taplist.catalog.service.StyleImportService;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
@@ -29,7 +33,24 @@ public class BjcpStyleController {
   }
 
   @GetMapping
-  @Operation(summary = "List BJCP styles (server-side filters: year, q on code/name)")
+  @Operation(
+      summary = "List BJCP styles",
+      description =
+          "Server-side filters: `year` (guideline year), `q` (substring match on code or name).\n"
+              + "Pagination via `page,size,sort` (e.g., `sort=code,asc`).")
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "Paged styles",
+        content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                    @ExampleObject(
+                        name = "StylesPage",
+                        value =
+                            "{\n  \"content\": [{\n    \"id\": 101, \"code\": \"18B\", \"name\": \"American Pale Ale\", \"guidelineYear\": 2015\n  }],\n  \"pageable\": {\"pageNumber\":0,\"pageSize\":50},\n  \"totalElements\": 1, \"totalPages\": 1\n}")))
+  })
   public Page<BjcpStyle> list(
       @RequestParam(value = "year", required = false) Integer year,
       @RequestParam(value = "q", required = false) String q,
@@ -53,6 +74,17 @@ public class BjcpStyleController {
   }
 
   @GetMapping("/{id}")
+  @Operation(summary = "Get BJCP style by id")
+  @ApiResponse(
+      responseCode = "200",
+      description = "Style",
+      content =
+          @Content(
+              mediaType = "application/json",
+              examples =
+                  @ExampleObject(
+                      value =
+                          "{\"id\":101,\"code\":\"18B\",\"name\":\"American Pale Ale\",\"guidelineYear\":2015}")))
   public ResponseEntity<BjcpStyle> get(@PathVariable Long id) {
     return repo.findById(id).map(ResponseEntity::ok).orElse(ResponseEntity.notFound().build());
   }


### PR DESCRIPTION
P1/P2: Styles lookup OpenAPI docs and Admin UX docs polish.\n\n- Add OpenAPI examples and descriptions for BJCP styles list/get (filters, pagination)\n- Enhance recipes-import.md with curl examples, Problem JSON examples, and Swagger links\n\nReview entry: docs/tech/reviewbranches/20250917-styles-openapi-docs.md\nTask: docs/techtasks/112-genie-catalog-tasks.md