### PR TITLE
feat(taplist): Big‑Board mode + projection-backed read (taplist_view)

### DIFF
--- a/docs/tech/reviewbranches/20250917-big-board-mode.md
+++ b/docs/tech/reviewbranches/20250917-big-board-mode.md
@@ -1,0 +1,14 @@
+# feature/api/big-board-mode
+
+- Area: api
+- Owner: ${AGENT_ROLE:-unknown}
+- Task: <docs/techtasks/...>
+- Summary: <purpose>
+- Scope: <paths>
+- Risk: low
+- Test Plan: <steps>
+- Status: proposed
+- PR: <tbd>
+
+## Notes
+- <design notes>

--- a/src/main/java/com/mythictales/bms/taplist/controller/TaplistController.java
+++ b/src/main/java/com/mythictales/bms/taplist/controller/TaplistController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import com.mythictales.bms.taplist.domain.Tap;
 import com.mythictales.bms.taplist.repo.TapRepository;
+import com.mythictales.bms.taplist.repo.TaplistViewRepository;
 import com.mythictales.bms.taplist.security.CurrentUser;
 import com.mythictales.bms.taplist.service.TapService;
 
@@ -19,10 +20,13 @@ import com.mythictales.bms.taplist.service.TapService;
 public class TaplistController {
   private final TapRepository taps;
   private final TapService tapService;
+  private final TaplistViewRepository taplistViews;
 
-  public TaplistController(TapRepository taps, TapService tapService) {
+  public TaplistController(
+      TapRepository taps, TapService tapService, TaplistViewRepository taplistViews) {
     this.taps = taps;
     this.tapService = tapService;
+    this.taplistViews = taplistViews;
   }
 
   @GetMapping("/taplist")
@@ -37,6 +41,27 @@ public class TaplistController {
     }
     model.addAttribute("taps", tapList);
     return "taplist/list";
+  }
+
+  @GetMapping("/taplist/board")
+  public String taplistBoard(
+      @RequestParam(value = "venueId", required = false) Long venueId,
+      @RequestParam(value = "taproomId", required = false) Long taproomId,
+      @RequestParam(value = "barId", required = false) Long barId,
+      @RequestParam(value = "refreshSeconds", required = false, defaultValue = "15") int refreshSeconds,
+      Model model) {
+    if (venueId != null) {
+      model.addAttribute("projections", taplistViews.findByVenueIdOrderByTapIdAsc(venueId));
+    } else {
+      // fallback to live taps when venueId not provided
+      List<Tap> tapList =
+          taproomId != null
+              ? taps.findByTaproomId(taproomId)
+              : (barId != null ? taps.findByBarId(barId) : taps.findAll());
+      model.addAttribute("taps", tapList);
+    }
+    model.addAttribute("refreshSeconds", Math.max(5, Math.min(120, refreshSeconds)));
+    return "taplist/board";
   }
 
   @PostMapping("/taps/{id}/tapKeg")

--- a/src/main/java/com/mythictales/bms/taplist/domain/TaplistView.java
+++ b/src/main/java/com/mythictales/bms/taplist/domain/TaplistView.java
@@ -1,0 +1,60 @@
+package com.mythictales.bms.taplist.domain;
+
+import java.time.Instant;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "taplist_view")
+public class TaplistView {
+  @Id
+  @Column(name = "tap_id")
+  private Long tapId;
+
+  @Column(name = "venue_id")
+  private Long venueId;
+
+  @Column(name = "beer_name")
+  private String beerName;
+
+  private String style;
+  private Double abv;
+
+  @Column(name = "remaining_ounces")
+  private Double remainingOunces;
+
+  @Column(name = "total_ounces")
+  private Double totalOunces;
+
+  @Column(name = "fill_percent")
+  private Integer fillPercent;
+
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt = Instant.now();
+
+  public TaplistView() {}
+
+  public TaplistView(Long tapId) {
+    this.tapId = tapId;
+  }
+
+  public Long getTapId() { return tapId; }
+  public void setTapId(Long tapId) { this.tapId = tapId; }
+  public Long getVenueId() { return venueId; }
+  public void setVenueId(Long venueId) { this.venueId = venueId; }
+  public String getBeerName() { return beerName; }
+  public void setBeerName(String beerName) { this.beerName = beerName; }
+  public String getStyle() { return style; }
+  public void setStyle(String style) { this.style = style; }
+  public Double getAbv() { return abv; }
+  public void setAbv(Double abv) { this.abv = abv; }
+  public Double getRemainingOunces() { return remainingOunces; }
+  public void setRemainingOunces(Double remainingOunces) { this.remainingOunces = remainingOunces; }
+  public Double getTotalOunces() { return totalOunces; }
+  public void setTotalOunces(Double totalOunces) { this.totalOunces = totalOunces; }
+  public Integer getFillPercent() { return fillPercent; }
+  public void setFillPercent(Integer fillPercent) { this.fillPercent = fillPercent; }
+  public Instant getUpdatedAt() { return updatedAt; }
+  public void setUpdatedAt(Instant updatedAt) { this.updatedAt = updatedAt; }
+}
+

--- a/src/main/java/com/mythictales/bms/taplist/repo/TaplistViewRepository.java
+++ b/src/main/java/com/mythictales/bms/taplist/repo/TaplistViewRepository.java
@@ -1,0 +1,12 @@
+package com.mythictales.bms.taplist.repo;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.mythictales.bms.taplist.domain.TaplistView;
+
+public interface TaplistViewRepository extends JpaRepository<TaplistView, Long> {
+  List<TaplistView> findByVenueIdOrderByTapIdAsc(Long venueId);
+}
+

--- a/src/main/java/com/mythictales/bms/taplist/service/TaplistProjectionUpdater.java
+++ b/src/main/java/com/mythictales/bms/taplist/service/TaplistProjectionUpdater.java
@@ -1,0 +1,71 @@
+package com.mythictales.bms.taplist.service;
+
+import java.time.Instant;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.mythictales.bms.taplist.domain.*;
+import com.mythictales.bms.taplist.events.TaproomEvents.*;
+import com.mythictales.bms.taplist.repo.TapRepository;
+import com.mythictales.bms.taplist.repo.TaplistViewRepository;
+
+@Component
+public class TaplistProjectionUpdater {
+  private final TapRepository taps;
+  private final TaplistViewRepository viewRepo;
+
+  public TaplistProjectionUpdater(TapRepository taps, TaplistViewRepository viewRepo) {
+    this.taps = taps;
+    this.viewRepo = viewRepo;
+  }
+
+  @EventListener
+  @Transactional
+  public void onTapped(KegTapped evt) { refreshTap(evt.tapId()); }
+
+  @EventListener
+  @Transactional
+  public void onPoured(BeerPoured evt) { refreshTap(evt.tapId()); }
+
+  @EventListener
+  @Transactional
+  public void onBlown(KegBlown evt) { refreshTap(evt.tapId()); }
+
+  @EventListener
+  @Transactional
+  public void onUntapped(KegUntapped evt) { refreshTap(evt.tapId()); }
+
+  private void refreshTap(Long tapId) {
+    Tap tap = taps.findById(tapId).orElse(null);
+    if (tap == null) return;
+    TaplistView v = viewRepo.findById(tapId).orElse(new TaplistView(tapId));
+    v.setVenueId(tap.getVenue() != null ? tap.getVenue().getId() : null);
+    if (tap.getKeg() != null && tap.getKeg().getBeer() != null) {
+      Beer beer = tap.getKeg().getBeer();
+      v.setBeerName(beer.getName());
+      v.setStyle(beer.getStyle());
+      v.setAbv(beer.getAbv());
+      Double total = tap.getKeg().getTotalOunces();
+      Double remain = tap.getKeg().getRemainingOunces();
+      v.setTotalOunces(total);
+      v.setRemainingOunces(remain);
+      int pct = 0;
+      if (total != null && total > 0 && remain != null && remain >= 0) {
+        pct = (int) Math.round(100.0 * remain / total);
+      }
+      v.setFillPercent(pct);
+    } else {
+      v.setBeerName(null);
+      v.setStyle(null);
+      v.setAbv(null);
+      v.setRemainingOunces(null);
+      v.setTotalOunces(null);
+      v.setFillPercent(null);
+    }
+    v.setUpdatedAt(Instant.now());
+    viewRepo.save(v);
+  }
+}
+

--- a/src/main/resources/db/migration/V5__taplist_projections.sql
+++ b/src/main/resources/db/migration/V5__taplist_projections.sql
@@ -1,0 +1,16 @@
+-- Projections: taplist_view for fast read of venue tap state
+
+create table if not exists taplist_view (
+  tap_id bigint primary key,
+  venue_id bigint,
+  beer_name varchar(255),
+  style varchar(255),
+  abv double,
+  remaining_ounces double,
+  total_ounces double,
+  fill_percent integer,
+  updated_at timestamp not null
+);
+
+create index if not exists idx_tlv_venue on taplist_view(venue_id);
+

--- a/src/main/resources/templates/taplist/board.html
+++ b/src/main/resources/templates/taplist/board.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8"/>
+  <title>Taplist — Big Board</title>
+  <meta th:attr="http-equiv='refresh', content=${refreshSeconds}"/>
+  <link rel="stylesheet" th:href="@{/css/app.css}"/>
+  <style>
+    body{background:#0b0e12;color:#e9eef5}
+    header{padding:1rem 2rem}
+    h1{font-size:2rem;margin:0}
+    .board{padding:0 2rem}
+    .row{display:grid;grid-template-columns:80px 1fr 160px;gap:1rem;align-items:center;padding:.6rem 0;border-bottom:1px solid #223041}
+    .tapno{font-size:2rem;color:#a7c0e8;text-align:right}
+    .beer{font-size:1.6rem}
+    .style{font-size:1rem;color:#9db0c9}
+    .status{justify-self:end}
+    .pill{padding:.25rem .6rem;border-radius:999px;background:#1b2533;color:#cfe1ff}
+    .low .pill{background:#41222b;color:#ffd6df}
+  </style>
+  </head>
+<body>
+  <header><h1>Taplist</h1></header>
+  <main class="board">
+    <!-- Prefer projections when present -->
+    <div th:if="${projections != null}" th:each="p : ${projections}" th:classappend="${p.fillPercent != null and p.fillPercent <= 10} ? ' low' : null" class="row">
+      <div class="tapno" th:text="${p.tapId}">1</div>
+      <div>
+        <div class="beer" th:text="${p.beerName != null ? p.beerName : 'Empty'}">Beer</div>
+        <div class="style" th:if="${p.beerName != null}" th:text="${p.style + ' • ' + p.abv + '% ABV'}">Style • ABV</div>
+      </div>
+      <div class="status">
+        <span class="pill" th:if="${p.fillPercent != null}" th:text="${p.fillPercent + '%'}">75%</span>
+        <span class="pill" th:if="${p.fillPercent == null}">EMPTY</span>
+      </div>
+    </div>
+
+    <!-- Fallback to live taps when projections not provided -->
+    <div th:if="${projections == null}" th:each="t : ${taps}" th:classappend="${t.keg != null && t.keg.fillPercent <= 10} ? ' low' : null" class="row">
+      <div class="tapno" th:text="${t.number}">1</div>
+      <div>
+        <div class="beer" th:text="${t.keg != null ? t.keg.beer.name : 'Empty'}">Beer</div>
+        <div class="style" th:if="${t.keg != null}" th:text="${t.keg.beer.style + ' • ' + t.keg.beer.abv + '% ABV'}">Style • ABV</div>
+      </div>
+      <div class="status">
+        <span class="pill" th:if="${t.keg != null}" th:text="${t.keg.fillPercent + '%'}">75%</span>
+        <span class="pill" th:if="${t.keg == null}">EMPTY</span>
+      </div>
+    </div>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
Implements Big‑Board mode and projection read model.\n\n- Route: GET /taplist/board?venueId=…&refreshSeconds=15\n- Template: taplist/board.html (large display, auto-refresh)\n- Projections: V5 Flyway (taplist_view), TaplistView entity/repo, TaplistProjectionUpdater listens to taproom events\n- Controller: board prefers projections (by venue), fallback to live taps\n\nReview entry: docs/tech/reviewbranches/20250917-big-board-mode.md