### PR TITLE
Add admin taproom events view

### DIFF
--- a/src/main/java/com/mythictales/bms/taplist/controller/AdminSiteEventsController.java
+++ b/src/main/java/com/mythictales/bms/taplist/controller/AdminSiteEventsController.java
@@ -1,0 +1,77 @@
+package com.mythictales.bms.taplist.controller;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.mythictales.bms.taplist.domain.KegEvent;
+import com.mythictales.bms.taplist.domain.Taproom;
+import com.mythictales.bms.taplist.repo.BreweryRepository;
+import com.mythictales.bms.taplist.repo.KegEventRepository;
+import com.mythictales.bms.taplist.repo.TaproomRepository;
+
+@Controller
+@RequestMapping("/admin/site/events")
+public class AdminSiteEventsController {
+
+  private static final int PAGE_SIZE = 25;
+
+  private final KegEventRepository events;
+  private final BreweryRepository breweries;
+  private final TaproomRepository taprooms;
+
+  public AdminSiteEventsController(
+      KegEventRepository events, BreweryRepository breweries, TaproomRepository taprooms) {
+    this.events = events;
+    this.breweries = breweries;
+    this.taprooms = taprooms;
+  }
+
+  @GetMapping
+  public String list(
+      @RequestParam(name = "breweryId", required = false) Long breweryId,
+      @RequestParam(name = "taproomId", required = false) Long taproomId,
+      @RequestParam(name = "page", defaultValue = "0") int page,
+      Model model) {
+
+    Long normalizedBreweryId = normalizeId(breweryId);
+    Long normalizedTaproomId = normalizeId(taproomId);
+
+    Pageable pageable = PageRequest.of(Math.max(page, 0), PAGE_SIZE);
+    Page<KegEvent> eventsPage =
+        events.findEventsFiltered(normalizedBreweryId, normalizedTaproomId, pageable);
+
+    List<Taproom> taproomChoices =
+        normalizedBreweryId != null
+            ? taprooms.findByBreweryId(normalizedBreweryId)
+            : taprooms.findAll(Sort.by("name"));
+
+    Integer previousPage =
+        eventsPage.hasPrevious() ? eventsPage.previousPageable().getPageNumber() : null;
+    Integer nextPage = eventsPage.hasNext() ? eventsPage.nextPageable().getPageNumber() : null;
+
+    model.addAttribute("events", eventsPage);
+    model.addAttribute("breweries", breweries.findAll(Sort.by("name")));
+    model.addAttribute("taprooms", taproomChoices);
+    model.addAttribute("selectedBreweryId", normalizedBreweryId);
+    model.addAttribute("selectedTaproomId", normalizedTaproomId);
+    model.addAttribute("pageSize", PAGE_SIZE);
+    model.addAttribute("previousPage", previousPage);
+    model.addAttribute("nextPage", nextPage);
+
+    return "admin/site-events";
+  }
+
+  private Long normalizeId(Long id) {
+    return Optional.ofNullable(id).filter(value -> value > 0).orElse(null);
+  }
+}

--- a/src/main/java/com/mythictales/bms/taplist/repo/KegEventRepository.java
+++ b/src/main/java/com/mythictales/bms/taplist/repo/KegEventRepository.java
@@ -50,4 +50,29 @@ public interface KegEventRepository extends JpaRepository<KegEvent, Long> {
         ORDER BY e.atTime DESC
     """)
   List<KegEvent> findByVenueIdOrderByAtTimeDesc(@Param("venueId") Long venueId);
+
+  @Query(
+      value =
+          """
+        SELECT e FROM KegEvent e
+        JOIN e.placement p
+        JOIN p.tap t
+        LEFT JOIN t.taproom tr
+        LEFT JOIN tr.brewery br
+        WHERE (:breweryId IS NULL OR br.id = :breweryId)
+          AND (:taproomId IS NULL OR tr.id = :taproomId)
+        ORDER BY e.atTime DESC
+    """,
+      countQuery =
+          """
+        SELECT COUNT(e) FROM KegEvent e
+        JOIN e.placement p
+        JOIN p.tap t
+        LEFT JOIN t.taproom tr
+        LEFT JOIN tr.brewery br
+        WHERE (:breweryId IS NULL OR br.id = :breweryId)
+          AND (:taproomId IS NULL OR tr.id = :taproomId)
+    """)
+  Page<KegEvent> findEventsFiltered(
+      @Param("breweryId") Long breweryId, @Param("taproomId") Long taproomId, Pageable pageable);
 }

--- a/src/main/resources/templates/admin/site-events.html
+++ b/src/main/resources/templates/admin/site-events.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Taproom Events</title>
+    <link rel="stylesheet" th:href="@{/css/app.css}" />
+  </head>
+  <body>
+    <header>
+      <h1>Taproom Events</h1>
+      <p><a class="btn" th:href="@{/admin/site}">⟵ Back to Site Admin</a></p>
+    </header>
+    <main>
+      <section class="filters">
+        <form method="get" class="filter-form">
+          <label for="breweryId">Brewery</label>
+          <select id="breweryId" name="breweryId" onchange="this.form.submit()">
+            <option th:value="" th:selected="${selectedBreweryId == null}">All Breweries</option>
+            <option
+              th:each="brewery : ${breweries}"
+              th:value="${brewery.id}"
+              th:text="${brewery.name}"
+              th:selected="${selectedBreweryId != null and brewery.id == selectedBreweryId}">
+              Brewery
+            </option>
+          </select>
+
+          <label for="taproomId">Taproom</label>
+          <select id="taproomId" name="taproomId" onchange="this.form.submit()">
+            <option th:value="" th:selected="${selectedTaproomId == null}">All Taprooms</option>
+            <option
+              th:each="taproom : ${taprooms}"
+              th:value="${taproom.id}"
+              th:text="${taproom.name}"
+              th:selected="${selectedTaproomId != null and taproom.id == selectedTaproomId}">
+              Taproom
+            </option>
+          </select>
+          <noscript>
+            <button type="submit">Filter</button>
+          </noscript>
+        </form>
+      </section>
+
+      <section class="events">
+        <p th:if="${events.content.isEmpty()}">No events match the selected filters.</p>
+        <table th:if="${!events.content.isEmpty()}">
+          <thead>
+            <tr>
+              <th>When</th>
+              <th>Event</th>
+              <th>Brewery</th>
+              <th>Taproom</th>
+              <th>Tap #</th>
+              <th>Beer</th>
+              <th>Ounces</th>
+              <th>Actor</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr th:each="event : ${events.content}">
+              <td th:text="${#temporals.format(event.atTime, 'yyyy-MM-dd HH:mm')}"></td>
+              <td th:text="${event.type}"></td>
+              <td
+                th:text="${event.placement.tap.taproom != null ? event.placement.tap.taproom.brewery.name : '—'}"></td>
+              <td th:text="${event.placement.tap.taproom != null ? event.placement.tap.taproom.name : '—'}"></td>
+              <td th:text="${event.placement.tap.number}"></td>
+              <td
+                th:text="${event.placement.keg.beer != null ? event.placement.keg.beer.name : 'Unassigned'}"></td>
+              <td th:text="${event.ounces != null ? #numbers.formatDecimal(event.ounces, 1, 1) : '—'}"></td>
+              <td th:text="${event.actor != null ? event.actor.username : 'system'}"></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="pagination" th:if="${!events.content.isEmpty()}">
+          <a
+            th:if="${previousPage != null}"
+            th:href="@{/admin/site/events(page=${previousPage},breweryId=${selectedBreweryId},taproomId=${selectedTaproomId})}"
+            class="btn">Previous</a>
+          <span>
+            Page <span th:text="${events.number + 1}"></span> of
+            <span th:text="${events.totalPages == 0 ? 1 : events.totalPages}"></span>
+          </span>
+          <a
+            th:if="${nextPage != null}"
+            th:href="@{/admin/site/events(page=${nextPage},breweryId=${selectedBreweryId},taproomId=${selectedTaproomId})}"
+            class="btn">Next</a>
+        </div>
+      </section>
+    </main>
+    <div th:replace="~{fragments/footer :: footer}"></div>
+  </body>
+</html>

--- a/src/main/resources/templates/admin/site.html
+++ b/src/main/resources/templates/admin/site.html
@@ -13,6 +13,9 @@
       <p>
         <a class="btn" th:href="@{/admin/users}">Manage Users</a>
       </p>
+      <p>
+        <a class="btn" th:href="@{/admin/site/events}">View Taproom Events</a>
+      </p>
       <h2>Breweries</h2>
       <ul>
         <li th:each="b : ${breweries}" th:text="${b.name}">Brewery</li>

--- a/src/test/java/com/mythictales/bms/taplist/controller/AdminSiteEventsControllerTest.java
+++ b/src/test/java/com/mythictales/bms/taplist/controller/AdminSiteEventsControllerTest.java
@@ -1,0 +1,82 @@
+package com.mythictales.bms.taplist.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.view.InternalResourceViewResolver;
+
+import com.mythictales.bms.taplist.repo.BreweryRepository;
+import com.mythictales.bms.taplist.repo.KegEventRepository;
+import com.mythictales.bms.taplist.repo.TaproomRepository;
+
+class AdminSiteEventsControllerTest {
+
+  private KegEventRepository events;
+  private BreweryRepository breweries;
+  private TaproomRepository taprooms;
+  private MockMvc mvc;
+
+  @BeforeEach
+  void setup() {
+    events = mock(KegEventRepository.class);
+    breweries = mock(BreweryRepository.class);
+    taprooms = mock(TaproomRepository.class);
+
+    InternalResourceViewResolver viewResolver = new InternalResourceViewResolver();
+    viewResolver.setPrefix("/templates/");
+    viewResolver.setSuffix(".html");
+
+    mvc =
+        MockMvcBuilders.standaloneSetup(new AdminSiteEventsController(events, breweries, taprooms))
+            .setViewResolvers(viewResolver)
+            .build();
+  }
+
+  @Test
+  void listsEventsWithoutFilters() throws Exception {
+    when(events.findEventsFiltered(isNull(), isNull(), any(Pageable.class)))
+        .thenReturn(new PageImpl<>(List.of()));
+    when(breweries.findAll(any(Sort.class))).thenReturn(List.of());
+    when(taprooms.findAll(any(Sort.class))).thenReturn(List.of());
+
+    mvc.perform(get("/admin/site/events"))
+        .andExpect(status().isOk())
+        .andExpect(model().attributeExists("events", "breweries", "taprooms"));
+
+    ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+    verify(events).findEventsFiltered(isNull(), isNull(), pageableCaptor.capture());
+    Pageable pageable = pageableCaptor.getValue();
+    assertThat(pageable.getPageNumber()).isZero();
+    assertThat(pageable.getPageSize()).isEqualTo(25);
+
+    verify(taprooms).findAll(any(Sort.class));
+    verifyNoMoreInteractions(taprooms);
+  }
+
+  @Test
+  void filtersTaproomsWhenBrewerySelected() throws Exception {
+    when(events.findEventsFiltered(eq(5L), isNull(), any(Pageable.class)))
+        .thenReturn(new PageImpl<>(List.of()));
+    when(breweries.findAll(any(Sort.class))).thenReturn(List.of());
+    when(taprooms.findByBreweryId(5L)).thenReturn(List.of());
+
+    mvc.perform(get("/admin/site/events").param("breweryId", "5"))
+        .andExpect(status().isOk())
+        .andExpect(model().attribute("selectedBreweryId", 5L));
+
+    verify(taprooms).findByBreweryId(5L);
+    verify(taprooms, never()).findAll(any(Sort.class));
+  }
+}


### PR DESCRIPTION
## Summary

Adds an admin-facing taproom events listing with brewery/taproom filters and pagination.

Branch entry: docs/tech/reviewbranches/20250917-kafka-streaming.md

## Scope of changes

- Areas: api
- Key paths touched:
  - src/main/java/com/mythictales/bms/taplist/controller/AdminSiteEventsController.java
  - src/main/java/com/mythictales/bms/taplist/repo/KegEventRepository.java
  - src/main/resources/templates/admin/site-events.html
  - src/main/resources/templates/admin/site.html
  - src/test/java/com/mythictales/bms/taplist/controller/AdminSiteEventsControllerTest.java

## Validation

- [x] Built locally (`mvn verify`)
- [ ] SpotBugs high-severity clean
- [ ] Swagger UI loads (`/swagger-ui.html`)
- [ ] Manual test steps and results: _Not run this session_

## Risks & Rollback Plan

JPQL pagination and joins may add load on large datasets; rollback by reverting the controller/template addition and repository query.
