### PR TITLE
Add Make targets to start/stop staging and prod stacks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ IMAGE    := mythictales/$(APP_NAME):latest
 PORT     := 8080
 JAVA_OPTS ?=
 
-.PHONY: help run build test package clean format check-format docker-build docker-run docker-stop docker-rm spotbugs spotbugs-strict setup-commit-template db-up-staging db-stop-staging db-up-prod db-stop-prod kafka-up kafka-down kafka-logs
+.PHONY: help run build test package clean format check-format docker-build docker-run docker-stop docker-rm spotbugs spotbugs-strict setup-commit-template db-up-staging db-stop-staging db-up-prod db-stop-prod kafka-up kafka-down kafka-logs staging_up prod_up staging_stop prod_stop
 
 help:
 	@echo "Targets:"
@@ -31,6 +31,10 @@ help:
 	@echo "  kafka-up      - Start dev Kafka stack"
 	@echo "  kafka-down    - Stop dev Kafka stack"
 	@echo "  kafka-logs    - Tail Kafka broker logs"
+	@echo "  staging_up    - Start staging Postgres and Kafka"
+	@echo "  staging_stop  - Stop staging Postgres and Kafka"
+	@echo "  prod_up       - Start prod Postgres and Kafka"
+	@echo "  prod_stop     - Stop prod Postgres and Kafka"
 	@echo "  setup-commit-template - Configure git commit.template to .gitmessage.txt"
 
 run:
@@ -97,6 +101,18 @@ kafka-down:
 
 kafka-logs:
 	docker compose -f docker/compose/kafka-dev.yml logs -f kafka
+
+staging_up: db-up-staging kafka-up
+	@echo "Staging Postgres and Kafka stack started"
+
+prod_up: db-up-prod kafka-up
+	@echo "Prod Postgres and Kafka stack started"
+
+staging_stop: kafka-down db-stop-staging
+	@echo "Staging Postgres and Kafka stack stopped"
+
+prod_stop: kafka-down db-stop-prod
+	@echo "Prod Postgres and Kafka stack stopped"
 
 setup-commit-template:
 	git config commit.template .gitmessage.txt


### PR DESCRIPTION
## Summary

Adds convenience Make targets to start/stop staging and prod Postgres plus the Kafka dev stack in one command.

Branch entry: docs/tech/reviewbranches/20250917-kafka-streaming.md

## Scope of changes

- Areas: platform
- Key paths touched:
  - Makefile

## Validation

- [ ] Built locally (`mvn verify`)
- [ ] SpotBugs high-severity clean
- [ ] Swagger UI loads (`/swagger-ui.html`)
- [ ] Manual test steps and results: _Not run this session_

## Risks & Rollback Plan

Low risk; commands wrap existing docker compose tasks. Roll back by removing the new Make targets.
