### PR TITLE
Publish taproom keg activity events to Kafka

### DIFF
--- a/docker/compose/kafka-dev.yml
+++ b/docker/compose/kafka-dev.yml
@@ -37,7 +37,7 @@ services:
     command: >-
       set -euo pipefail
       BROKER=kafka:9092
-      create() { kafka-topics.sh --bootstrap-server "$BROKER" --create --if-not-exists --topic "$1" --partitions 6 --replication-factor 1; }
+      create() { kafka-topics.sh --bootstrap-server "$$BROKER" --create --if-not-exists --topic "$$1" --partitions 6 --replication-factor 1; }
       for topic in \
         prodinventory.events.v1 \
         keginventory.events.v1 \
@@ -51,9 +51,9 @@ services:
         billing.events.v1 \
         compliance.events.v1 \
         iam.events.v1; do
-        create "$topic"
+        create "$$topic"
       done
-      kafka-topics.sh --bootstrap-server "$BROKER" --list
+      kafka-topics.sh --bootstrap-server "$$BROKER" --list
 
   kafka-ui:
     image: provectuslabs/kafka-ui:latest

--- a/docs/ops/kafka-domain-events.md
+++ b/docs/ops/kafka-domain-events.md
@@ -30,6 +30,13 @@
   - `bms.kafka.sample.facility-id`
   - `bms.kafka.sample.venue-id`
 
+## Taproom Domain Events
+
+- `TapService` emits taproom lifecycle events to `taproom.events.v1` when keg activity occurs.
+- Event types: `KegTapped`, `BeerPoured`, `KegBlown`, `KegUntapped`.
+- Payload fields include tap/taproom/venue identifiers, keg/beer metadata, actor details, and pour ounces when applicable.
+- Headers follow the global contract (`breweryId`, `facilityId` = taproom, `venueId`, `eventType`, `occurredAt`, `traceId`).
+
 ## Local Development
 
 1. Start Kafka stack: `docker compose -f docker/compose/kafka-dev.yml up -d`
@@ -53,4 +60,3 @@
 
 - `DomainEventPublisherIT` (Testcontainers Kafka) verifies publish headers and payload contracts
 - Unit coverage should validate metadata helpers (`partitionKey`, trace ID resolution) as additional publishers emerge
-

--- a/src/main/java/com/mythictales/bms/taplist/service/TapService.java
+++ b/src/main/java/com/mythictales/bms/taplist/service/TapService.java
@@ -1,7 +1,11 @@
 package com.mythictales.bms.taplist.service;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -9,6 +13,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.mythictales.bms.taplist.domain.*;
 import com.mythictales.bms.taplist.repo.*;
+import com.mythictales.bms.taplist.kafka.DomainEventMetadata;
+import com.mythictales.bms.taplist.kafka.DomainEventPublisher;
 
 @Service
 public class TapService {
@@ -18,6 +24,7 @@ public class TapService {
   private final KegEventRepository events;
   private final UserAccountRepository users;
   private final ApplicationEventPublisher eventsBus;
+  private final Optional<DomainEventPublisher> domainEvents;
 
   public TapService(
       TapRepository t,
@@ -25,13 +32,15 @@ public class TapService {
       KegPlacementRepository p,
       KegEventRepository e,
       UserAccountRepository users,
-      ApplicationEventPublisher eventsBus) {
+      ApplicationEventPublisher eventsBus,
+      Optional<DomainEventPublisher> domainEvents) {
     this.taps = t;
     this.kegs = k;
     this.placements = p;
     this.events = e;
     this.users = users;
     this.eventsBus = eventsBus;
+    this.domainEvents = domainEvents == null ? Optional.empty() : domainEvents;
   }
 
   // Overloads without actor for system/data initialization
@@ -71,9 +80,10 @@ public class TapService {
     taps.save(tap);
     kegs.save(keg);
     KegPlacement placement = placements.save(new KegPlacement(tap, keg));
+    UserAccount actor = loadActor(actorUserId);
     KegEvent evt = new KegEvent(placement, KegEventType.TAP, null);
-    if (actorUserId != null) {
-      users.findById(actorUserId).ifPresent(evt::setActor);
+    if (actor != null) {
+      evt.setActor(actor);
     }
     events.save(evt);
     if (tap.getVenue() != null) {
@@ -81,6 +91,7 @@ public class TapService {
           new com.mythictales.bms.taplist.events.TaproomEvents.KegTapped(
               tap.getId(), keg.getId(), tap.getVenue().getId(), actorUserId));
     }
+    publishTaproomEvent("KegTapped", tap, keg, null, actor);
   }
 
   @Transactional
@@ -91,6 +102,7 @@ public class TapService {
     keg.setRemainingOunces(0);
     keg.setStatus(KegStatus.BLOWN);
     kegs.save(keg);
+    UserAccount actor = loadActor(actorUserId);
     placements
         .findFirstByTapIdAndEndedAtIsNull(tapId)
         .ifPresent(
@@ -98,8 +110,8 @@ public class TapService {
               p.setEndedAt(Instant.now());
               placements.save(p);
               KegEvent evt = new KegEvent(p, KegEventType.BLOW, null);
-              if (actorUserId != null) {
-                users.findById(actorUserId).ifPresent(evt::setActor);
+              if (actor != null) {
+                evt.setActor(actor);
               }
               events.save(evt);
             });
@@ -113,6 +125,8 @@ public class TapService {
           new com.mythictales.bms.taplist.events.TaproomEvents.KegUntapped(
               tap.getId(), keg.getId(), tap.getVenue().getId(), actorUserId));
     }
+    publishTaproomEvent("KegBlown", tap, keg, null, actor);
+    publishTaproomEvent("KegUntapped", tap, keg, null, actor);
   }
 
   @Transactional
@@ -136,13 +150,14 @@ public class TapService {
     }
     keg.setRemainingOunces(Math.max(0, remain));
     kegs.save(keg);
+    UserAccount actor = loadActor(actorUserId);
     placements
         .findFirstByTapIdAndEndedAtIsNull(tapId)
         .ifPresent(
             p -> {
               KegEvent evt = new KegEvent(p, KegEventType.POUR, ounces);
-              if (actorUserId != null) {
-                users.findById(actorUserId).ifPresent(evt::setActor);
+              if (actor != null) {
+                evt.setActor(actor);
               }
               events.save(evt);
             });
@@ -151,6 +166,7 @@ public class TapService {
           new com.mythictales.bms.taplist.events.TaproomEvents.BeerPoured(
               tap.getId(), keg.getId(), tap.getVenue().getId(), ounces, actorUserId));
     }
+    publishTaproomEvent("BeerPoured", tap, keg, ounces, actor);
     if (keg.getRemainingOunces() <= 0) {
       keg.setStatus(KegStatus.BLOWN);
       kegs.save(keg);
@@ -161,8 +177,8 @@ public class TapService {
                 p.setEndedAt(Instant.now());
                 placements.save(p);
                 KegEvent evt = new KegEvent(p, KegEventType.UNTAP, null);
-                if (actorUserId != null) {
-                  users.findById(actorUserId).ifPresent(evt::setActor);
+                if (actor != null) {
+                  evt.setActor(actor);
                 }
                 events.save(evt);
               });
@@ -176,6 +192,112 @@ public class TapService {
             new com.mythictales.bms.taplist.events.TaproomEvents.KegUntapped(
                 tap.getId(), keg.getId(), tap.getVenue().getId(), actorUserId));
       }
+      publishTaproomEvent("KegBlown", tap, keg, null, actor);
+      publishTaproomEvent("KegUntapped", tap, keg, null, actor);
     }
+  }
+
+  private UserAccount loadActor(Long actorUserId) {
+    if (actorUserId == null) {
+      return null;
+    }
+    return users.findById(actorUserId).orElse(null);
+  }
+
+  private void publishTaproomEvent(
+      String eventType, Tap tap, Keg keg, Double ounces, UserAccount actor) {
+    domainEvents.ifPresent(
+        publisher -> {
+          if (tap == null) {
+            return;
+          }
+          Brewery brewery = resolveBrewery(tap, keg);
+          if (brewery == null || brewery.getId() == null) {
+            return;
+          }
+          UUID breweryId = uuidFor("brewery", brewery.getId());
+          Optional<UUID> facilityId = optionalUuid("taproom", tap.getTaproom());
+          Optional<UUID> venueId = optionalUuid("venue", tap.getVenue());
+
+          Map<String, Object> payload = new LinkedHashMap<>();
+          payload.put("eventType", eventType);
+          payload.put("tapId", tap.getId());
+          payload.put("tapNumber", tap.getNumber());
+          payload.put("taproomId", tap.getTaproom() != null ? tap.getTaproom().getId() : null);
+          payload.put("taproomName", tap.getTaproom() != null ? tap.getTaproom().getName() : null);
+          payload.put("venueId", tap.getVenue() != null ? tap.getVenue().getId() : null);
+          payload.put("venueName", tap.getVenue() != null ? tap.getVenue().getName() : null);
+          if (keg != null) {
+            payload.put("kegId", keg.getId());
+            payload.put("kegSerialNumber", keg.getSerialNumber());
+            payload.put("kegStatus", keg.getStatus() != null ? keg.getStatus().name() : null);
+            payload.put("kegRemainingOunces", keg.getRemainingOunces());
+            payload.put("kegTotalOunces", keg.getTotalOunces());
+            Brewery kegBrewery = keg.getBrewery();
+            if (kegBrewery != null) {
+              payload.put("kegBreweryId", kegBrewery.getId());
+              payload.put("kegBreweryName", kegBrewery.getName());
+            }
+            Beer beer = keg.getBeer();
+            if (beer != null) {
+              payload.put("beerId", beer.getId());
+              payload.put("beerName", beer.getName());
+              payload.put("beerStyle", beer.getStyle());
+            }
+          }
+          if (ounces != null) {
+            payload.put("ounces", ounces);
+          }
+          if (actor != null) {
+            payload.put("actorUserId", actor.getId());
+            payload.put("actorUsername", actor.getUsername());
+            if (actor.getRole() != null) {
+              payload.put("actorRole", actor.getRole().name());
+            }
+          }
+
+          DomainEventMetadata metadata =
+              new DomainEventMetadata(
+                  "taproom",
+                  eventType,
+                  breweryId,
+                  facilityId,
+                  venueId,
+                  Instant.now(),
+                  Optional.empty());
+          publisher.publish(metadata, payload);
+        });
+  }
+
+  private Brewery resolveBrewery(Tap tap, Keg keg) {
+    if (tap.getTaproom() != null && tap.getTaproom().getBrewery() != null) {
+      return tap.getTaproom().getBrewery();
+    }
+    if (tap.getVenue() != null && tap.getVenue().getBrewery() != null) {
+      return tap.getVenue().getBrewery();
+    }
+    if (keg != null && keg.getBrewery() != null) {
+      return keg.getBrewery();
+    }
+    return null;
+  }
+
+  private UUID uuidFor(String scope, Long id) {
+    String value = scope + ":" + id;
+    return UUID.nameUUIDFromBytes(value.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private Optional<UUID> optionalUuid(String scope, Taproom taproom) {
+    if (taproom == null || taproom.getId() == null) {
+      return Optional.empty();
+    }
+    return Optional.of(uuidFor(scope, taproom.getId()));
+  }
+
+  private Optional<UUID> optionalUuid(String scope, Venue venue) {
+    if (venue == null || venue.getId() == null) {
+      return Optional.empty();
+    }
+    return Optional.of(uuidFor(scope, venue.getId()));
   }
 }

--- a/src/test/java/com/mythictales/bms/taplist/service/TapServiceKafkaEventsTest.java
+++ b/src/test/java/com/mythictales/bms/taplist/service/TapServiceKafkaEventsTest.java
@@ -1,0 +1,178 @@
+package com.mythictales.bms.taplist.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import com.mythictales.bms.taplist.domain.Beer;
+import com.mythictales.bms.taplist.domain.Brewery;
+import com.mythictales.bms.taplist.domain.Keg;
+import com.mythictales.bms.taplist.domain.KegPlacement;
+import com.mythictales.bms.taplist.domain.KegSizeSpec;
+import com.mythictales.bms.taplist.domain.KegStatus;
+import com.mythictales.bms.taplist.domain.Role;
+import com.mythictales.bms.taplist.domain.Tap;
+import com.mythictales.bms.taplist.domain.Taproom;
+import com.mythictales.bms.taplist.domain.UserAccount;
+import com.mythictales.bms.taplist.domain.Venue;
+import com.mythictales.bms.taplist.kafka.DomainEventMetadata;
+import com.mythictales.bms.taplist.kafka.DomainEventPublisher;
+import com.mythictales.bms.taplist.repo.KegEventRepository;
+import com.mythictales.bms.taplist.repo.KegPlacementRepository;
+import com.mythictales.bms.taplist.repo.KegRepository;
+import com.mythictales.bms.taplist.repo.TapRepository;
+import com.mythictales.bms.taplist.repo.UserAccountRepository;
+
+@ExtendWith(MockitoExtension.class)
+class TapServiceKafkaEventsTest {
+
+  @Mock private TapRepository tapRepository;
+  @Mock private KegRepository kegRepository;
+  @Mock private KegPlacementRepository placementRepository;
+  @Mock private KegEventRepository eventRepository;
+  @Mock private UserAccountRepository userRepository;
+  @Mock private ApplicationEventPublisher applicationEventPublisher;
+  @Mock private DomainEventPublisher domainEventPublisher;
+
+  @Captor private ArgumentCaptor<DomainEventMetadata> metadataCaptor;
+  @Captor private ArgumentCaptor<Object> payloadCaptor;
+
+  private TapService tapService;
+  private Brewery brewery;
+  private Taproom taproom;
+  private Venue venue;
+  private Tap tap;
+  private Keg keg;
+  private UserAccount actor;
+
+  @BeforeEach
+  void setUp() {
+    tapService =
+        new TapService(
+            tapRepository,
+            kegRepository,
+            placementRepository,
+            eventRepository,
+            userRepository,
+            applicationEventPublisher,
+            Optional.of(domainEventPublisher));
+
+    brewery = new Brewery("Mythic");
+    brewery.setId(1L);
+
+    taproom = new Taproom("Main Room", brewery);
+    taproom.setId(10L);
+
+    venue = new Venue();
+    venue.setId(20L);
+    venue.setName("Main Venue");
+    venue.setBrewery(brewery);
+
+    tap = new Tap(5);
+    tap.setId(30L);
+    tap.setTaproom(taproom);
+    tap.setVenue(venue);
+
+    Beer beer = new Beer("Mystic IPA", "IPA", 6.5);
+    beer.setId(40L);
+
+    KegSizeSpec size = new KegSizeSpec("HALF", 15.5);
+    size.setGallons(15.5);
+
+    keg = new Keg();
+    keg.setId(50L);
+    keg.setSerialNumber("K-123");
+    keg.setBrewery(brewery);
+    keg.setSize(size);
+    keg.setBeer(beer);
+    keg.setRemainingOunces(1984);
+    keg.setTotalOunces(1984);
+    keg.setStatus(KegStatus.TAPPED);
+    tap.setKeg(keg);
+
+    actor = new UserAccount("tapadmin", "pw", Role.TAPROOM_ADMIN);
+    actor.setId(60L);
+
+    when(tapRepository.findById(tap.getId())).thenReturn(Optional.of(tap));
+    org.mockito.Mockito.lenient()
+        .when(placementRepository.save(any(KegPlacement.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    when(userRepository.findById(actor.getId())).thenReturn(Optional.of(actor));
+  }
+
+  @Test
+  void tapKegPublishesKafkaEvent() {
+    when(kegRepository.findById(keg.getId())).thenReturn(Optional.of(keg));
+    when(placementRepository.findFirstByTapIdAndEndedAtIsNull(tap.getId()))
+        .thenReturn(Optional.empty());
+
+    tapService.tapKeg(tap.getId(), keg.getId(), actor.getId());
+
+    verify(domainEventPublisher).publish(metadataCaptor.capture(), payloadCaptor.capture());
+    DomainEventMetadata metadata = metadataCaptor.getValue();
+    assertThat(metadata.domain()).isEqualTo("taproom");
+    assertThat(metadata.eventType()).isEqualTo("KegTapped");
+    assertThat(metadata.breweryId()).isEqualTo(uuidFor("brewery", brewery.getId()));
+    assertThat(metadata.facilityId()).contains(uuidFor("taproom", taproom.getId()));
+    assertThat(metadata.venueId()).contains(uuidFor("venue", venue.getId()));
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> payload = (Map<String, Object>) payloadCaptor.getValue();
+    assertThat(payload).containsEntry("tapId", tap.getId());
+    assertThat(payload).containsEntry("kegId", keg.getId());
+    assertThat(payload).containsEntry("actorUserId", actor.getId());
+    assertThat(payload.get("beerName")).isEqualTo("Mystic IPA");
+  }
+
+  @Test
+  void pourPublishesBeerPouredEvent() {
+    KegPlacement placement = new KegPlacement(tap, keg);
+    when(placementRepository.findFirstByTapIdAndEndedAtIsNull(tap.getId()))
+        .thenReturn(Optional.of(placement));
+
+    tapService.pour(tap.getId(), 12.0, actor.getId());
+
+    verify(domainEventPublisher).publish(metadataCaptor.capture(), payloadCaptor.capture());
+    DomainEventMetadata metadata = metadataCaptor.getValue();
+    assertThat(metadata.eventType()).isEqualTo("BeerPoured");
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> payload = (Map<String, Object>) payloadCaptor.getValue();
+    assertThat(payload).containsEntry("ounces", 12.0);
+  }
+
+  @Test
+  void blowPublishesBlownAndUntappedEvents() {
+    KegPlacement placement = new KegPlacement(tap, keg);
+    when(placementRepository.findFirstByTapIdAndEndedAtIsNull(tap.getId()))
+        .thenReturn(Optional.of(placement));
+
+    tapService.blow(tap.getId(), actor.getId());
+
+    verify(domainEventPublisher, times(2))
+        .publish(metadataCaptor.capture(), payloadCaptor.capture());
+    assertThat(metadataCaptor.getAllValues())
+        .extracting(DomainEventMetadata::eventType)
+        .containsExactly("KegBlown", "KegUntapped");
+  }
+
+  private UUID uuidFor(String scope, Long id) {
+    return UUID.nameUUIDFromBytes((scope + ":" + id).getBytes(StandardCharsets.UTF_8));
+  }
+}


### PR DESCRIPTION
## Summary

Publish taproom keg activity events to Kafka with proper metadata and unit coverage.

Branch entry: docs/tech/reviewbranches/20250917-kafka-streaming.md

## Scope of changes

- Areas: platform
- Key paths touched:
  - src/main/java/com/mythictales/bms/taplist/service/TapService.java
  - src/test/java/com/mythictales/bms/taplist/service/TapServiceKafkaEventsTest.java
  - docs/ops/kafka-domain-events.md

## Validation

- [x] Built locally (`mvn verify`)
- [ ] SpotBugs high-severity clean
- [ ] Swagger UI loads (`/swagger-ui.html`)
- [ ] Manual test steps and results: _Not run this session_

## Risks & Rollback Plan

Publishing now occurs on every taproom action. Roll back by reverting the TapService changes if Kafka consumers encounter issues.
