### PR TITLE
Fix Kafka dev compose startup

### DIFF
--- a/docker/compose/kafka-dev.yml
+++ b/docker/compose/kafka-dev.yml
@@ -1,5 +1,4 @@
 # Dev Kafka (KRaft) with topic bootstrap and UI
-version: "3.9"
 
 services:
   kafka:
@@ -10,6 +9,7 @@ services:
       KAFKA_CFG_NODE_ID: 1
       KAFKA_CFG_PROCESS_ROLES: broker,controller
       KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
       KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
       KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
       KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
@@ -33,27 +33,34 @@ services:
     depends_on:
       kafka:
         condition: service_healthy
-    entrypoint: ["/bin/bash", "-lc"]
-    command: >-
-      set -euo pipefail
-      BROKER=kafka:9092
-      create() { kafka-topics.sh --bootstrap-server "$$BROKER" --create --if-not-exists --topic "$$1" --partitions 6 --replication-factor 1; }
-      for topic in \
-        prodinventory.events.v1 \
-        keginventory.events.v1 \
-        taproom.events.v1 \
-        catalog.events.v1 \
-        sales.events.v1 \
-        distribution.events.v1 \
-        procurement.events.v1 \
-        maintenance.events.v1 \
-        analytics.events.v1 \
-        billing.events.v1 \
-        compliance.events.v1 \
-        iam.events.v1; do
-        create "$$topic"
-      done
-      kafka-topics.sh --bootstrap-server "$$BROKER" --list
+    network_mode: service:kafka
+    command:
+      - /bin/bash
+      - -lc
+      - |
+        set -euo pipefail
+        PATH="/opt/bitnami/kafka/bin:$$PATH"
+        BROKER="localhost:9092"
+        create() {
+          kafka-topics.sh --bootstrap-server "$$BROKER" --create --if-not-exists --topic "$$1" --partitions 6 --replication-factor 1
+        }
+        for topic in \
+          prodinventory.events.v1 \
+          keginventory.events.v1 \
+          taproom.events.v1 \
+          catalog.events.v1 \
+          sales.events.v1 \
+          distribution.events.v1 \
+          procurement.events.v1 \
+          maintenance.events.v1 \
+          analytics.events.v1 \
+          billing.events.v1 \
+          compliance.events.v1 \
+          iam.events.v1
+        do
+          create "$$topic"
+        done
+        kafka-topics.sh --bootstrap-server "$$BROKER" --list
 
   kafka-ui:
     image: provectuslabs/kafka-ui:latest


### PR DESCRIPTION
## Summary

Fix the Kafka dev compose stack so `make staging_up` boots Postgres and Kafka without manual tweaks.

Branch entry: docs/tech/reviewbranches/20250917-kafka-streaming.md

## Scope of changes

- Areas: platform
- Key paths touched:
  - docker/compose/kafka-dev.yml

## Validation

- [ ] Built locally (`mvn verify`)
- [ ] SpotBugs high-severity clean
- [ ] Swagger UI loads (`/swagger-ui.html`)
- [x] Manual test steps and results: `docker compose -f docker/compose/kafka-dev.yml up -d` (topics created successfully)

## Risks & Rollback Plan

Low risk. Revert docker/compose/kafka-dev.yml to previous version if the compose stack misbehaves.
