### PR TITLE
Remove duplicate Flyway V5 migration

### DIFF
--- a/docs/tech/reviewbranches/20250918-drop-duplicate-v5.md
+++ b/docs/tech/reviewbranches/20250918-drop-duplicate-v5.md
@@ -1,0 +1,14 @@
+# feature/platform/drop-duplicate-v5
+
+- Area: platform
+- Owner: genie-keginventory
+- Task: docs/techtasks/101-genie-platform-data-tasks.md (Flyway baseline guardrails)
+- Summary: Remove duplicate Flyway V5 migration causing startup failure
+- Scope: src/main/resources/db/migration/V5__add_siteadmin_user.sql
+- Risk: low — deletes redundant migration file already superseded
+- Test Plan: mvn flyway:validate
+- Status: in-progress
+- PR: <tbd>
+
+## Notes
+- Staging branch introduced `V5__taplist_projections.sql`; this branch keeps that migration as the sole V5.

--- a/src/main/resources/db/migration/V5__add_siteadmin_user.sql
+++ b/src/main/resources/db/migration/V5__add_siteadmin_user.sql
@@ -1,1 +1,0 @@
--- Migration: Add siteadmin user


### PR DESCRIPTION
Context/Motivation\n- Startup failed in staging due to two V5 migrations colliding.\n- We only need the taplist projections variant introduced upstream.\n\nChanges\n- Delete the redundant V5__add_siteadmin_user.sql Flyway script.\n- Record the clean-up in the review branch entry.\n\nRisks & Rollback\n- Low risk: removing a no-op migration; rollback by restoring file if needed.\n\nValidation\n- mvn flyway:validate (fails: local Flyway CLI plugin issue due to placeholder resolver; same error before change).\n\nReferences\n- docs/techtasks/101-genie-platform-data-tasks.md\n

## Summary

Describe the change and why it’s needed. Link to the branch entry in `docs/tech/reviewbranches`.

Branch entry: <!-- e.g., docs/tech/reviewbranches/20250914-feature-api-pour-validation-422.md -->

## Scope of changes

- Areas: <!-- api | platform | both -->
- Key paths touched:

## Validation

- [ ] Built locally (`mvn verify`)
- [ ] SpotBugs high-severity clean
- [ ] Swagger UI loads (`/swagger-ui.html`)
- [ ] Manual test steps and results:

## Risks & Rollback Plan

Call out known risks and how to revert safely.

