### PR TITLE
Adopt enterprise admin layout and UI playground

### DIFF
--- a/docs/tech/reviewbranches/20250919-storybook-ui-playground.md
+++ b/docs/tech/reviewbranches/20250919-storybook-ui-playground.md
@@ -1,0 +1,17 @@
+# feature/platform/storybook-ui-playground
+
+- Area: platform
+- Owner: techlead
+- Task: docs/techtasks/000-technical-backlog.md (enterprise UI system)
+- Summary: Scaffold a Storybook-style UI playground to showcase design tokens and core components.
+- Scope: src/main/java/com/mythictales/bms/taplist/controller/UiPlaygroundController.java, src/main/resources/templates/ui-playground/**, src/main/resources/static/css/ui-playground.css
+- Risk: low
+- Test Plan: Manual — run `mvn spring-boot:run` and open http://localhost:8080/ui/playground
+- Status: in-progress
+- PR: <tbd>
+
+## Notes
+- Playground lists stories for foundations, buttons, cards, and tables with dev ready markup.
+- Page is intended for dev-only visibility; consider auth guard or profile check if needed before release.
+- App shell and design tokens now applied to admin/site and admin/users screens via new layout.
+- Migrated remaining admin templates (brewery, taproom, bar, venue, catalog, events) onto the shared shell and component system with live metrics sourced from repositories.

--- a/docs/ui-playground.md
+++ b/docs/ui-playground.md
@@ -1,0 +1,36 @@
+# UI Playground
+
+The dev-only playground (Storybook-style) lives at `/ui/playground` and is active when the `dev` Spring profile is enabled.
+
+## Run locally
+
+```bash
+mvn spring-boot:run
+# browser → http://localhost:8080/ui/playground
+```
+
+## Structure
+
+- `UiPlaygroundController` — lists available stories and maps query string `story` → Thymeleaf fragment.
+- `templates/ui-playground/index.html` — shell layout with persistent navigation and stage area.
+- `templates/ui-playground/stories/` — individual story fragments (`foundations`, `buttons`, `cards`, `tables`, `forms`, `overlays`, `visualizations`).
+- `static/css/ui-playground.css` — design token showcase + component styling.
+
+## Current stories
+
+- Foundations — color tokens, typography scale, spacing rhythm.
+- Buttons — primary/secondary/ghost/danger states.
+- Cards — metric and content cards with supporting text.
+- Tables — enterprise data grid with toolbar and pagination.
+- Forms — input grids, validation messaging, and filter chips.
+- Overlays & Dialogs — modal, slide-over, and toast patterns.
+- Visualizations — sparkline, capacity ring, segmented distribution bar.
+
+## Adding a new story
+
+1. Create a fragment under `templates/ui-playground/stories/<name>.html` exposing `th:fragment="story"`.
+2. Register the story in `UiPlaygroundController.STORIES` with id, label, and description.
+3. Add a `th:case` entry in `templates/ui-playground/index.html` to load the new fragment.
+4. Provide component-specific styling within the existing CSS or a scoped addition.
+
+> Keep examples self-contained and focused on enterprise admin use cases so stakeholders can sign off quickly before porting styles into production templates.

--- a/src/main/java/com/mythictales/bms/taplist/controller/AdminBarController.java
+++ b/src/main/java/com/mythictales/bms/taplist/controller/AdminBarController.java
@@ -1,10 +1,14 @@
 package com.mythictales.bms.taplist.controller;
 
+import java.util.List;
+
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 
+import com.mythictales.bms.taplist.domain.Tap;
 import com.mythictales.bms.taplist.repo.TapRepository;
 import com.mythictales.bms.taplist.security.CurrentUser;
 
@@ -19,9 +23,23 @@ public class AdminBarController {
 
   @GetMapping
   public String page(@AuthenticationPrincipal CurrentUser user, Model model) {
-    if (user != null && user.getBarId() != null)
-      model.addAttribute("taps", taps.findByBarId(user.getBarId()));
-    else model.addAttribute("taps", java.util.List.of());
+    List<Tap> tapList = List.of();
+    if (user != null && user.getBarId() != null) {
+      tapList = taps.findByBarId(user.getBarId());
+    }
+
+    long activeTaps =
+        tapList.stream().filter(t -> t.getKeg() != null).count();
+    long lowAlerts =
+        tapList.stream()
+            .filter(t -> t.getKeg() != null)
+            .filter(t -> t.getKeg().getFillPercent() <= 10)
+            .count();
+
+    model.addAttribute("taps", tapList);
+    model.addAttribute("tapCount", tapList.size());
+    model.addAttribute("activeTapCount", activeTaps);
+    model.addAttribute("lowTapAlertCount", lowAlerts);
     return "admin/bar";
   }
 }

--- a/src/main/java/com/mythictales/bms/taplist/controller/AdminBeerController.java
+++ b/src/main/java/com/mythictales/bms/taplist/controller/AdminBeerController.java
@@ -73,6 +73,11 @@ public class AdminBeerController {
     model.addAttribute("stylesByCategory", stylesByCategory);
     model.addAttribute("year", year);
     model.addAttribute("q", q);
+    model.addAttribute("beerCount", beerList.size());
+    model.addAttribute(
+        "linkedBeerCount", beerList.stream().filter(b -> b.getStyleRef() != null).count());
+    model.addAttribute("styleCategoryCount", stylesByCategory.size());
+    model.addAttribute("styleOptionCount", styleList.size());
     return "admin/beer";
   }
 

--- a/src/main/java/com/mythictales/bms/taplist/controller/AdminBreweryController.java
+++ b/src/main/java/com/mythictales/bms/taplist/controller/AdminBreweryController.java
@@ -207,11 +207,32 @@ public class AdminBreweryController {
       }
       model.addAttribute("breweryUsers", userList);
       model.addAttribute("userVenueId", userVenueId);
+
+      int taproomCount = trList.size();
+      int activeTapHandles =
+          activeKegsByTaproom.values().stream().mapToInt(Integer::intValue).sum();
+      int availableKegs = unassigned != null ? unassigned.size() : 0;
+      int distributedKegs = assigned != null ? assigned.size() : 0;
+      int returnedKegCount = returned != null ? returned.size() : 0;
+      int breweryUserCount = userList.size();
+
+      model.addAttribute("taproomCount", taproomCount);
+      model.addAttribute("activeTapHandles", activeTapHandles);
+      model.addAttribute("availableKegCount", availableKegs);
+      model.addAttribute("distributedKegCount", distributedKegs);
+      model.addAttribute("returnedKegCount", returnedKegCount);
+      model.addAttribute("breweryUserCount", breweryUserCount);
     } else {
       model.addAttribute("taprooms", java.util.List.of());
       model.addAttribute("kegs", java.util.List.of());
       model.addAttribute("venues", java.util.List.of());
       model.addAttribute("breweryUsers", java.util.List.of());
+      model.addAttribute("taproomCount", 0);
+      model.addAttribute("activeTapHandles", 0);
+      model.addAttribute("availableKegCount", 0);
+      model.addAttribute("distributedKegCount", 0);
+      model.addAttribute("returnedKegCount", 0);
+      model.addAttribute("breweryUserCount", 0);
     }
     model.addAttribute("allStatuses", KegStatus.values());
     model.addAttribute("tab", tab);

--- a/src/main/java/com/mythictales/bms/taplist/controller/AdminCatalogController.java
+++ b/src/main/java/com/mythictales/bms/taplist/controller/AdminCatalogController.java
@@ -53,6 +53,7 @@ public class AdminCatalogController {
     }
     model.addAttribute("recipes", list);
     model.addAttribute("q", q);
+    model.addAttribute("recipeCount", list.size());
     return "admin/catalog-recipes";
   }
 
@@ -67,6 +68,11 @@ public class AdminCatalogController {
       }
     }
     model.addAttribute("recipe", r);
+    model.addAttribute("fermentableCount", r.getFermentables().size());
+    model.addAttribute("hopCount", r.getHops().size());
+    model.addAttribute("yeastCount", r.getYeasts().size());
+    model.addAttribute("miscCount", r.getMiscs().size());
+    model.addAttribute("mashStepCount", r.getMashSteps().size());
     return "admin/catalog-recipe-edit";
   }
 

--- a/src/main/java/com/mythictales/bms/taplist/controller/AdminSiteController.java
+++ b/src/main/java/com/mythictales/bms/taplist/controller/AdminSiteController.java
@@ -2,25 +2,45 @@ package com.mythictales.bms.taplist.controller;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 
-import com.mythictales.bms.taplist.repo.*;
+import com.mythictales.bms.taplist.domain.KegStatus;
+import com.mythictales.bms.taplist.repo.BarRepository;
+import com.mythictales.bms.taplist.repo.BreweryRepository;
+import com.mythictales.bms.taplist.repo.KegRepository;
+import com.mythictales.bms.taplist.repo.TaproomRepository;
 
 @Controller
 @RequestMapping("/admin/site")
 public class AdminSiteController {
   private final BreweryRepository breweries;
   private final BarRepository bars;
+  private final TaproomRepository taprooms;
+  private final KegRepository kegs;
 
-  public AdminSiteController(BreweryRepository breweries, BarRepository bars) {
+  public AdminSiteController(
+      BreweryRepository breweries,
+      BarRepository bars,
+      TaproomRepository taprooms,
+      KegRepository kegs) {
     this.breweries = breweries;
     this.bars = bars;
+    this.taprooms = taprooms;
+    this.kegs = kegs;
   }
 
   @GetMapping
   public String page(Model model) {
     model.addAttribute("breweries", breweries.findAll());
     model.addAttribute("bars", bars.findAll());
+    model.addAttribute("breweryCount", breweries.count());
+    model.addAttribute("barCount", bars.count());
+    model.addAttribute("taproomCount", taprooms.count());
+    model.addAttribute(
+        "tappedKegCount", kegs.findByStatus(KegStatus.TAPPED).size());
+    model.addAttribute(
+        "distributedKegCount", kegs.findByStatus(KegStatus.DISTRIBUTED).size());
     return "admin/site";
   }
 }

--- a/src/main/java/com/mythictales/bms/taplist/controller/AdminVenueController.java
+++ b/src/main/java/com/mythictales/bms/taplist/controller/AdminVenueController.java
@@ -1,11 +1,14 @@
 package com.mythictales.bms.taplist.controller;
 
+import java.util.List;
+
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
+import com.mythictales.bms.taplist.domain.Tap;
 import com.mythictales.bms.taplist.repo.TapRepository;
 import com.mythictales.bms.taplist.repo.VenueRepository;
 
@@ -24,7 +27,18 @@ public class AdminVenueController {
   @GetMapping("/admin/venue/{venueId}")
   public String venueAdmin(@PathVariable Long venueId, Model model) {
     model.addAttribute("venue", venues.findById(venueId).orElse(null));
-    model.addAttribute("taps", taps.findByVenueId(venueId));
+    List<Tap> tapList = taps.findByVenueId(venueId);
+    long activeTaps = tapList.stream().filter(t -> t.getKeg() != null).count();
+    long lowAlerts =
+        tapList.stream()
+            .filter(t -> t.getKeg() != null)
+            .filter(t -> t.getKeg().getFillPercent() <= 10)
+            .count();
+
+    model.addAttribute("taps", tapList);
+    model.addAttribute("tapCount", tapList.size());
+    model.addAttribute("activeTapCount", activeTaps);
+    model.addAttribute("lowTapAlertCount", lowAlerts);
     return "admin/venue";
   }
 }

--- a/src/main/java/com/mythictales/bms/taplist/controller/UiPlaygroundController.java
+++ b/src/main/java/com/mythictales/bms/taplist/controller/UiPlaygroundController.java
@@ -1,0 +1,66 @@
+package com.mythictales.bms.taplist.controller;
+
+import java.util.List;
+import java.util.Locale;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Profile("dev")
+@Controller
+@RequestMapping("/ui/playground")
+public class UiPlaygroundController {
+
+  private static final List<Story> STORIES =
+      List.of(
+          new Story(
+              "foundations",
+              "Foundations",
+              "Color, typography, spacing tokens for the enterprise UI"),
+          new Story(
+              "buttons",
+              "Buttons",
+              "Primary, secondary, and ghost button treatments"),
+          new Story(
+              "cards",
+              "Cards",
+              "Metrics and content containers with headers and footers"),
+          new Story(
+              "tables",
+              "Tables",
+              "Data grid with zebra striping, badges, and bulk actions"),
+          new Story(
+              "forms",
+              "Forms",
+              "Input controls, validation states, and inline guidance"),
+          new Story(
+              "overlays",
+              "Overlays & Dialogs",
+              "Modal dialogs, slideovers, and toast notifications"),
+          new Story(
+              "visualizations",
+              "Visualizations",
+              "Spark lines, tank capacity, and progress indicators"));
+
+  @GetMapping
+  public String playground(@RequestParam(value = "story", required = false) String story, Model model) {
+    Story selected = selectStory(story);
+    model.addAttribute("stories", STORIES);
+    model.addAttribute("selectedStory", selected.id());
+    model.addAttribute("selectedStoryMeta", selected);
+    return "ui-playground/index";
+  }
+
+  private Story selectStory(String story) {
+    if (story == null || story.isBlank()) {
+      return STORIES.get(0);
+    }
+    String normalized = story.toLowerCase(Locale.ROOT);
+    return STORIES.stream().filter(s -> s.id().equals(normalized)).findFirst().orElse(STORIES.get(0));
+  }
+
+  public record Story(String id, String label, String description) {}
+}

--- a/src/main/resources/static/css/app.css
+++ b/src/main/resources/static/css/app.css
@@ -1,110 +1,765 @@
-:root { --radius: 14px; }
-* { box-sizing: border-box; }
-body { font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin:0; background:#0f1115; color:#eef2f7; }
-a { color:#9cc0ff; text-decoration:none; }
-.container { max-width: 1100px; margin: 0 auto; padding: 1rem; }
-header h1 { margin: .5rem 0; }
-nav a { margin-right: .5rem; }
-.table { width:100%; border-collapse: collapse; }
-.table th, .table td { padding:.6rem .5rem; border-bottom:1px solid #2a2f3a; vertical-align: middle; }
-.table th { text-align:left; color:#a8b3cf; font-weight:600; }
-.toolbar { margin: .5rem 0 1rem; }
-.btn { border:1px solid #384153; background:#1a2232; color:#eaf0ff; padding:.4rem .7rem; border-radius: var(--radius); cursor:pointer; }
-.btn:hover { background:#202a3d; }
-.btn.danger { background:#3a1c1c; border-color:#6a2a2a; }
-.btn.ghost { background:transparent; border-color:#384153; color:#a8b3cf; }
-.inline { display:inline-block; margin: 0 .25rem; }
-.field { margin-bottom: .9rem; }
-.field label { display:block; font-size:.9rem; color:#a8b3cf; margin-bottom:.25rem; }
-input, select { width: 100%; max-width: 22rem; padding:.45rem .5rem; border-radius: var(--radius); border:1px solid #384153; background:#0f131d; color:#eaf0ff; }
-.alert { background:#1f2a40; border:1px solid #2a3a5c; padding:.6rem .8rem; border-radius: var(--radius); margin-bottom:1rem; }
-.muted { color:#8a95ad; }
-.actions { display:flex; gap:.4rem; align-items:center; flex-wrap:wrap; }
+:root {
+  --color-surface-50: #f5f7fb;
+  --color-surface-100: #eef1f8;
+  --color-surface-200: #e4e8f2;
+  --color-surface-900: #1e2432;
+  --color-border-200: #d6dbea;
+  --color-border-300: #c5cad8;
+  --color-text-900: #111827;
+  --color-text-600: #4b5563;
+  --color-text-400: #9ca3af;
+  --color-primary-500: #2e5aac;
+  --color-primary-600: #274c92;
+  --color-success-500: #249f7f;
+  --color-warning-500: #c97a1e;
+  --color-critical-500: #c73e3e;
+  --color-info-500: #3a6ba5;
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 16px;
+  --shadow-sm: 0 6px 16px rgba(17, 24, 39, 0.08);
+  --shadow-md: 0 12px 28px rgba(17, 24, 39, 0.12);
+  --font-family-base: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
 
-/* Brewery Admin tabs, chips, badges */
-.tabs { display:flex; gap:.5rem; margin:.75rem 0 1rem; flex-wrap: wrap; }
-.tabs a { padding:.4rem .7rem; border-radius:8px; text-decoration:none; color:#cbd5e1; background:#111726; border:1px solid #222a3a; }
-.tabs a.active { background:#13203a; color:#9cc0ff; border-color:#2a3a5c; }
-.chip { display:inline-block; padding:.2rem .5rem; border:1px solid #2a2f3a; border-radius:999px; margin-left:.35rem; color:#cbd5e1; text-decoration:none; }
-.chip.active { background:#13203a; border-color:#2a3a5c; color:#9cc0ff; }
-.badge { display:inline-block; padding:.15rem .4rem; border-radius:6px; font-size:.85rem; }
-.badge.green { background:#114632; color:#9ef3c6; }
-.badge.blue { background:#102643; color:#9cc0ff; }
-.badge.purple { background:#1e123f; color:#cbb6ff; }
-.badge.orange { background:#3a2312; color:#ffd3a6; }
-.badge.red { background:#3a1212; color:#ffb4b4; }
-.badge.gray { background:#1c2432; color:#cbd5e1; }
+*, *::before, *::after {
+  box-sizing: border-box;
+}
 
-/* Fill bar with smooth shading by percentage */
-.fillbar { position: relative; width: 180px; height: 14px; background:#141926; border:1px solid #2b3447; border-radius: 999px; overflow:hidden; }
-.fillbar .fill {
-  position:absolute; top:0; left:0; height:100%;
-  /* gradient from green to amber to red using a hue rotation by width */
-  background: linear-gradient(90deg, #4ade80, #facc15, #f87171);
-  transition: width .35s ease;
+body {
+  margin: 0;
+  font-family: var(--font-family-base);
+  background: var(--color-surface-50);
+  color: var(--color-text-900);
+  line-height: 1.5;
+}
+
+a {
+  color: var(--color-primary-500);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+button, .btn {
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.app-shell {
+  min-height: 100vh;
+}
+
+.app-frame {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  min-height: 100vh;
+  background: var(--color-surface-50);
+}
+
+.app-nav {
+  background: var(--color-surface-900);
+  color: rgba(244, 247, 255, 0.9);
+  padding: 2rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.nav-brand .brand-mark {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.nav-brand .brand-app {
+  margin-top: 0.3rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.nav-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.nav-label {
+  margin: 0 0 0.25rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(244, 247, 255, 0.55);
+}
+
+.nav-section a {
+  color: rgba(244, 247, 255, 0.72);
+  padding: 0.45rem 0.6rem;
+  border-radius: var(--radius-sm);
+  transition: background 160ms ease, color 160ms ease;
+}
+
+.nav-section a:hover,
+.nav-section a.active {
+  background: rgba(46, 90, 172, 0.28);
+  color: #ffffff;
+}
+
+.nav-footer {
+  margin-top: auto;
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+}
+
+.nav-user {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.nav-user-name {
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.nav-user-role {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(244, 247, 255, 0.6);
+  font-size: 0.7rem;
+}
+
+.app-main {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: var(--color-surface-50);
+}
+
+.app-topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.75rem 2rem 1rem;
+  border-bottom: 1px solid var(--color-border-200);
+  background: rgba(255, 255, 255, 0.6);
+  backdrop-filter: blur(12px);
+}
+
+.topbar-titles h1 {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 600;
+}
+
+.topbar-subtitle {
+  margin: 0.35rem 0 0;
+  color: var(--color-text-600);
+  max-width: 640px;
+}
+
+.topbar-actions {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.container { max-width: 1100px; margin: 0 auto; padding: 1.5rem; }
+
+.app-content {
+  flex: 1;
+  padding: 2rem;
+  display: grid;
+  gap: 2rem;
+}
+
+.app-footer {
+  margin-top: auto;
+  padding: 1.2rem 2rem;
+  border-top: 1px solid var(--color-border-200);
+  background: #fff;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.footer-meta {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.9rem;
+  color: var(--color-text-600);
+}
+
+.footer-meta strong {
+  color: var(--color-text-900);
+}
+
+.footer-role {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--color-text-400);
+}
+
+.footer-actions .btn {
+  font-size: 0.9rem;
+}
+
+/* Buttons */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  font-weight: 600;
+  background: #ffffff;
+  color: var(--color-primary-500);
+  transition: background 160ms ease, color 160ms ease, box-shadow 160ms ease;
+}
+
+.btn.primary {
+  background: var(--color-primary-500);
+  color: #ffffff;
+  border-color: transparent;
+  box-shadow: 0 10px 24px rgba(46, 90, 172, 0.18);
+}
+
+.btn.primary:hover {
+  background: var(--color-primary-600);
+}
+
+.btn.secondary {
+  background: #edf2ff;
+  border-color: var(--color-primary-500);
+  color: var(--color-primary-500);
+}
+
+.btn.ghost {
+  background: transparent;
+  border-color: var(--color-border-200);
+  color: var(--color-text-600);
+}
+
+.btn.ghost:hover {
+  background: rgba(17, 24, 39, 0.04);
+  color: var(--color-text-900);
+}
+
+.btn.critical {
+  background: var(--color-critical-500);
+  color: #fff;
+  border-color: transparent;
+}
+
+.btn.critical.outline {
+  background: transparent;
+  color: var(--color-critical-500);
+  border-color: rgba(199, 62, 62, 0.55);
+}
+
+.btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
 }
 
 
-/* Pint glass indicator */
-.pint { display:block; }
-.pint stop { transition: stop-color .35s ease; }
-td .pint { margin-top: .2rem; margin-bottom: .2rem; }
+.page-section {
+  display: grid;
+  gap: 1rem;
+}
 
+.stacked-forms {
+  display: grid;
+  gap: 1rem;
+}
 
-/* Pint glass indicator + tooltip */
-.pint { display:block; }
-.pintwrap { position: relative; display: inline-block; }
-.debug-tooltip {
+.section-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.section-heading h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.inventory-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.inventory-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  background: #fff;
+  border: 1px solid var(--color-border-200);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+}
+
+/* Cards */
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+}
+
+.metric-card,
+.content-card {
+  background: #fff;
+  border: 1px solid var(--color-border-200);
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.metric-card header,
+.content-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.metric-card h3,
+.content-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.metric-value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--color-text-900);
+}
+
+.metric-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.metric-pill.success {
+  background: rgba(36, 159, 127, 0.12);
+  color: var(--color-success-500);
+}
+
+.metric-pill.warning {
+  background: rgba(201, 122, 30, 0.12);
+  color: var(--color-warning-500);
+}
+
+.metric-pill.critical {
+  background: rgba(199, 62, 62, 0.12);
+  color: var(--color-critical-500);
+}
+
+.metric-pill.info {
+  background: rgba(58, 107, 165, 0.12);
+  color: var(--color-info-500);
+}
+
+.content-card footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.content-card ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--color-text-600);
+}
+
+/* Tables */
+
+.table-wrapper {
+  background: #fff;
+  border: 1px solid var(--color-border-200);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+
+.table-wrapper .table {
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.table,
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  border: 1px solid var(--color-border-200);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+
+.table thead tr,
+.data-table thead tr {
+  background: rgba(17, 24, 39, 0.04);
+  text-align: left;
+}
+
+.table th,
+.table td,
+.data-table th,
+.data-table td {
+  padding: 0.75rem 1rem;
+  font-size: 0.95rem;
+  border-bottom: 1px solid var(--color-border-200);
+  color: var(--color-text-600);
+}
+
+.table th,
+.data-table th {
+  font-weight: 600;
+  color: var(--color-text-900);
+}
+
+.table tbody tr:nth-child(odd),
+.data-table tbody tr:nth-child(odd) {
+  background: rgba(17, 24, 39, 0.02);
+}
+
+.table tbody tr:last-child td,
+.data-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.table tbody tr.is-low td {
+  background: rgba(199, 62, 62, 0.08);
+}
+
+.table-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid var(--color-border-200);
+  background: rgba(17, 24, 39, 0.03);
+}
+
+.table-toolbar .toolbar-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.table-toolbar .toolbar-filters {
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+/* Forms */
+.form-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.form-group--full {
+  grid-column: 1 / -1;
+}
+
+.form-group label {
+  font-weight: 600;
+  color: var(--color-text-900);
+  font-size: 0.95rem;
+}
+
+.form-group input,
+.form-group select,
+input,
+select,
+textarea {
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border-200);
+  padding: 0.55rem 0.65rem;
+  font-size: 0.95rem;
+  background: #fff;
+  color: var(--color-text-900);
+  transition: border-color 140ms ease, box-shadow 140ms ease;
+}
+
+.form-group input:focus,
+.form-group select:focus,
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--color-primary-500);
+  box-shadow: 0 0 0 3px rgba(46, 90, 172, 0.2);
+}
+
+.field-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-600);
+}
+
+.has-error input,
+.has-error select {
+  border-color: rgba(199, 62, 62, 0.65);
+  box-shadow: 0 0 0 3px rgba(199, 62, 62, 0.2);
+}
+
+.field-error {
+  color: var(--color-critical-500);
+  font-size: 0.85rem;
+}
+
+.filter-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.filter-chip {
+  border-radius: 999px;
+  border: 1px solid var(--color-border-200);
+  padding: 0.3rem 0.8rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  background: #fff;
+  color: var(--color-text-600);
+}
+
+.filter-chip.active {
+  background: rgba(46, 90, 172, 0.12);
+  border-color: var(--color-primary-500);
+  color: var(--color-primary-500);
+}
+
+.form-inline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.form-inline .form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.form-inline .form-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.form-inline--compact {
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.form-inline--compact .form-group {
+  margin: 0;
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.sr-only {
   position: absolute;
-  bottom: 72px; left: 50%; transform: translateX(-50%);
-  background: #1f2a40; border: 1px solid #2a3a5c;
-  padding: .25rem .4rem; border-radius: 8px;
-  font-size: .75rem; white-space: nowrap;
-  opacity: 0; pointer-events: none; transition: opacity .15s ease;
-  box-shadow: 0 6px 18px rgba(0,0,0,.35);
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
+
+/* Tabs & badges */
+.tabs {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.tabs a {
+  padding: 0.35rem 0.75rem;
+  border: 1px solid var(--color-border-200);
+  border-radius: 999px;
+  color: var(--color-text-600);
+  background: #fff;
+}
+
+.tabs a.active {
+  color: var(--color-primary-500);
+  border-color: var(--color-primary-500);
+  background: rgba(46, 90, 172, 0.12);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.badge.green { background: rgba(36, 159, 127, 0.18); color: var(--color-success-500); }
+.badge.blue { background: rgba(46, 90, 172, 0.18); color: var(--color-primary-500); }
+.badge.orange { background: rgba(201, 122, 30, 0.18); color: var(--color-warning-500); }
+.badge.red { background: rgba(199, 62, 62, 0.18); color: var(--color-critical-500); }
+.badge.gray { background: rgba(17, 24, 39, 0.08); color: var(--color-text-600); }
+
+.alert {
+  background: #fff;
+  border: 1px solid var(--color-border-200);
+  border-left: 4px solid var(--color-warning-500);
+  padding: 0.9rem 1rem;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  color: var(--color-text-600);
+}
+
+.nowrap { white-space: nowrap; }
+
+.muted {
+  color: var(--color-text-600);
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+/* Legacy indicators retained for taplist */
+.fillbar {
+  position: relative;
+  width: 180px;
+  height: 14px;
+  background: rgba(17, 24, 39, 0.08);
+  border: 1px solid var(--color-border-200);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.fillbar .fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  background: linear-gradient(90deg, #4ade80, #facc15, #f87171);
+  transition: width 0.35s ease;
+}
+
+.pint { display: block; }
+.pint stop { transition: stop-color 0.35s ease; }
+
+.pintwrap { position: relative; display: inline-block; }
+.pintwrap .debug-tooltip {
+  position: absolute;
+  bottom: 72px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(17, 24, 39, 0.85);
+  color: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  padding: 0.25rem 0.4rem;
+  border-radius: 8px;
+  font-size: 0.75rem;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.35);
+  z-index: 20;
+}
+
 .pintwrap:hover .debug-tooltip { opacity: 1; }
 
-
-/* Low-keg pulse */
 .pintwrap.low {
   animation: lowPulse 1s ease-in-out infinite alternate;
-  /* extra outer glow for HTML element, complements inner SVG glow */
-  filter: drop-shadow(0 0 8px rgba(255,59,48,.55));
+  filter: drop-shadow(0 0 8px rgba(255, 59, 48, 0.45));
 }
-@keyframes lowPulse {
-  0%   { filter: drop-shadow(0 0 4px rgba(255,59,48,.35)); }
-  100% { filter: drop-shadow(0 0 16px rgba(255,59,48,.85)); }
-}
-
-
-/* Scope low-keg pulse/glow to the glass only */
-.pintglass.low {
-  animation: lowPulse 1s ease-in-out infinite alternate;
-  filter: drop-shadow(0 0 8px rgba(255,59,48,.55));
-}
-/* Tooltip layering */
-.pintwrap { position: relative; }
-.pintwrap .debug-tooltip { z-index: 20; }
-
-
-/* Taplist pint & tooltip */
-.pint { display:block; }
-.pintwrap { position: relative; display: inline-block; }
-.debug-tooltip {
-  position: absolute; bottom: 72px; left: 50%; transform: translateX(-50%);
-  background: #1f2a40; border: 1px solid #2a3a5c; padding: .25rem .4rem;
-  border-radius: 8px; font-size: .75rem; white-space: nowrap;
-  opacity: 0; pointer-events: none; transition: opacity .15s ease;
-  box-shadow: 0 6px 18px rgba(0,0,0,.35); z-index: 20;
-}
-.pintwrap:hover .debug-tooltip { opacity: 1; }
 
 .pintglass.low {
   animation: lowPulse 1s ease-in-out infinite alternate;
-  filter: drop-shadow(0 0 8px rgba(255,59,48,.55));
+  filter: drop-shadow(0 0 8px rgba(255, 59, 48, 0.45));
 }
+
 @keyframes lowPulse {
-  0%   { filter: drop-shadow(0 0 4px rgba(255,59,48,.35)); }
-  100% { filter: drop-shadow(0 0 16px rgba(255,59,48,.85)); }
+  0% { filter: drop-shadow(0 0 4px rgba(255, 59, 48, 0.25)); }
+  100% { filter: drop-shadow(0 0 12px rgba(255, 59, 48, 0.65)); }
+}
+
+/* Responsive */
+@media (max-width: 1080px) {
+  .app-frame {
+    grid-template-columns: 1fr;
+  }
+
+  .app-nav {
+    flex-direction: row;
+    align-items: flex-start;
+    overflow-x: auto;
+    gap: 2rem;
+  }
+
+  .nav-section {
+    min-width: 160px;
+  }
+}
+
+@media (max-width: 720px) {
+  .app-topbar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .container { max-width: 1100px; margin: 0 auto; padding: 1.5rem; }
+
+.app-content {
+    padding: 1.5rem;
+  }
+
+  .app-footer {
+    padding: 1rem 1.5rem;
+  }
 }

--- a/src/main/resources/static/css/ui-playground.css
+++ b/src/main/resources/static/css/ui-playground.css
@@ -1,0 +1,793 @@
+:root {
+  --storybook-surface: #f5f7fb;
+  --storybook-surface-strong: #ffffff;
+  --storybook-border: #d6dbea;
+  --storybook-border-strong: #c5cad8;
+  --storybook-nav: #1e2432;
+  --storybook-nav-text: #f4f7ff;
+  --storybook-primary: #2e5aac;
+  --storybook-primary-hover: #274c92;
+  --storybook-success: #249f7f;
+  --storybook-warning: #c97a1e;
+  --storybook-critical: #c73e3e;
+  --storybook-text-strong: #111827;
+  --storybook-text-muted: #4b5563;
+  --storybook-radius-sm: 4px;
+  --storybook-radius-md: 8px;
+  --storybook-shadow: 0 12px 32px rgba(17, 24, 39, 0.1);
+}
+
+body.ui-playground {
+  background: var(--storybook-surface);
+  color: var(--storybook-text-strong);
+  min-height: 100vh;
+}
+
+.playground-shell {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 0;
+  max-width: 1360px;
+  margin: 0 auto;
+  min-height: calc(100vh - 80px);
+  border-radius: var(--storybook-radius-md);
+  overflow: hidden;
+  box-shadow: var(--storybook-shadow);
+}
+
+.playground-nav {
+  background: var(--storybook-nav);
+  color: var(--storybook-nav-text);
+  padding: 2rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.nav-header .product-mark {
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.nav-subtitle {
+  margin-top: 0.4rem;
+  color: rgba(244, 247, 255, 0.75);
+  line-height: 1.5;
+}
+
+.story-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.story-list a {
+  color: rgba(244, 247, 255, 0.75);
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--storybook-radius-sm);
+  transition: background 160ms ease, color 160ms ease;
+}
+
+.story-list a:hover,
+.story-list a.active {
+  background: rgba(46, 90, 172, 0.28);
+  color: #ffffff;
+}
+
+.nav-description {
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: rgba(244, 247, 255, 0.72);
+}
+
+.playground-stage {
+  background: var(--storybook-surface-strong);
+  padding: 2.25rem 2.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.stage-header h1 {
+  font-size: 1.75rem;
+  margin: 0;
+  color: var(--storybook-text-strong);
+}
+
+.stage-header .stage-context {
+  margin-top: 0.35rem;
+  color: var(--storybook-text-muted);
+  max-width: 640px;
+}
+
+.story-section {
+  background: #fff;
+  border: 1px solid var(--storybook-border);
+  border-radius: var(--storybook-radius-md);
+  padding: 1.75rem;
+  box-shadow: 0 4px 18px rgba(17, 24, 39, 0.05);
+}
+
+.story-section h2 {
+  margin-top: 0;
+  font-size: 1.125rem;
+  color: var(--storybook-text-strong);
+}
+
+.story-section + .story-section {
+  margin-top: 1.5rem;
+}
+
+.swatch-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.swatch {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  background: rgba(17, 24, 39, 0.04);
+  padding: 0.75rem 1rem;
+  border-radius: var(--storybook-radius-md);
+  border: 1px solid rgba(17, 24, 39, 0.08);
+  color: inherit;
+}
+
+.swatch-chip {
+  width: 54px;
+  height: 54px;
+  border-radius: 12px;
+  background: var(--swatch-color);
+  display: inline-block;
+  border: 1px solid rgba(17, 24, 39, 0.12);
+}
+
+.type-stack {
+  display: grid;
+  gap: 1.1rem;
+}
+
+.type-label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--storybook-text-muted);
+  margin-bottom: 0.25rem;
+}
+
+.type-display { font-size: 2rem; font-weight: 700; }
+.type-headline { font-size: 1.5rem; font-weight: 600; }
+.type-title { font-size: 1.25rem; font-weight: 600; }
+.type-body { font-size: 1rem; }
+.type-caption { font-size: 0.875rem; font-weight: 500; }
+
+.spacing-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.spacing-chip {
+  --size: var(--space-size);
+  width: 60px;
+  height: 60px;
+  border-radius: var(--storybook-radius-md);
+  border: 1px dashed var(--storybook-border-strong);
+  background: rgba(46, 90, 172, 0.05);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  position: relative;
+}
+
+.spacing-chip::after {
+  content: '';
+  position: absolute;
+  width: var(--size);
+  height: var(--size);
+  border-radius: var(--storybook-radius-sm);
+  background: rgba(46, 90, 172, 0.35);
+}
+
+.story-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+}
+
+.story-btn {
+  font-family: inherit;
+  font-size: 0.95rem;
+  font-weight: 600;
+  border-radius: var(--storybook-radius-sm);
+  padding: 0.55rem 1.2rem;
+  border: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
+}
+
+.story-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+  box-shadow: none;
+}
+
+.btn-primary {
+  background: var(--storybook-primary);
+  color: #fff;
+  box-shadow: 0 10px 20px rgba(46, 90, 172, 0.2);
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: var(--storybook-primary-hover);
+  transform: translateY(-1px);
+}
+
+.btn-secondary {
+  background: #edf2ff;
+  color: var(--storybook-primary);
+  border: 1px solid var(--storybook-primary);
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--storybook-text-strong);
+  border: 1px solid var(--storybook-border);
+}
+
+.btn-ghost:hover {
+  background: rgba(17, 24, 39, 0.04);
+}
+
+.btn-ghost.danger { color: var(--storybook-critical); border-color: rgba(199, 62, 62, 0.45); }
+
+.btn-critical {
+  background: var(--storybook-critical);
+  color: #fff;
+  box-shadow: 0 10px 20px rgba(199, 62, 62, 0.2);
+}
+
+.btn-critical.outline {
+  background: transparent;
+  color: var(--storybook-critical);
+  border: 1px solid rgba(199, 62, 62, 0.55);
+  box-shadow: none;
+}
+
+.story-btn.icon i {
+  display: inline-block;
+  width: 0.65rem;
+  height: 0.65rem;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(-45deg);
+  margin-left: 0.25rem;
+}
+
+.card-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
+}
+
+.metric-card, .content-card {
+  background: var(--storybook-surface-strong);
+  border: 1px solid var(--storybook-border);
+  border-radius: var(--storybook-radius-md);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.metric-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.metric-label { color: var(--storybook-text-muted); font-size: 0.95rem; }
+
+.metric-value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--storybook-text-strong);
+}
+
+.metric-card footer {
+  color: var(--storybook-text-muted);
+  font-size: 0.9rem;
+}
+
+.metric-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.metric-pill.success { background: rgba(36, 159, 127, 0.12); color: var(--storybook-success); }
+.metric-pill.warning { background: rgba(201, 122, 30, 0.12); color: var(--storybook-warning); }
+.metric-pill.critical { background: rgba(199, 62, 62, 0.12); color: var(--storybook-critical); }
+
+.content-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.content-card h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.card-list {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--storybook-text-muted);
+  line-height: 1.6;
+}
+
+.content-card footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.table-wrapper {
+  background: #fff;
+  border: 1px solid var(--storybook-border);
+  border-radius: var(--storybook-radius-md);
+  overflow: hidden;
+}
+
+.table-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--storybook-border);
+  background: rgba(17, 24, 39, 0.02);
+}
+
+.toolbar-left, .toolbar-right {
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.table-search {
+  border-radius: var(--storybook-radius-sm);
+  border: 1px solid var(--storybook-border);
+  padding: 0.45rem 0.6rem;
+}
+
+.storybook-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.storybook-table thead {
+  background: rgba(17, 24, 39, 0.04);
+  text-align: left;
+}
+
+.storybook-table th, .storybook-table td {
+  padding: 0.75rem 1.25rem;
+  border-bottom: 1px solid var(--storybook-border);
+  font-size: 0.95rem;
+}
+
+.storybook-table tbody tr:nth-child(odd) {
+  background: rgba(17, 24, 39, 0.02);
+}
+
+.table-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.9rem 1.25rem;
+}
+
+.table-pagination {
+  display: flex;
+  gap: 0.6rem;
+}
+
+@media (max-width: 1100px) {
+  .playground-shell {
+    grid-template-columns: 1fr;
+  }
+  .playground-nav {
+    flex-direction: column;
+    gap: 1rem;
+  }
+}
+
+/* Forms */
+.storybook-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.form-group label {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--storybook-text-strong);
+}
+
+.form-group input,
+.form-group select {
+  border-radius: var(--storybook-radius-sm);
+  border: 1px solid var(--storybook-border);
+  padding: 0.55rem 0.65rem;
+  font-size: 0.95rem;
+  background: #fff;
+  transition: border-color 140ms ease, box-shadow 140ms ease;
+}
+
+.form-group input:focus,
+.form-group select:focus {
+  outline: none;
+  border-color: var(--storybook-primary);
+  box-shadow: 0 0 0 3px rgba(46, 90, 172, 0.2);
+}
+
+.select-wrap {
+  position: relative;
+}
+
+.select-wrap::after {
+  content: '';
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  width: 10px;
+  height: 10px;
+  border-right: 2px solid var(--storybook-text-muted);
+  border-bottom: 2px solid var(--storybook-text-muted);
+  transform: translateY(-50%) rotate(45deg);
+  pointer-events: none;
+}
+
+.field-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--storybook-text-muted);
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.has-error input {
+  border-color: rgba(199, 62, 62, 0.65);
+  box-shadow: 0 0 0 3px rgba(199, 62, 62, 0.2);
+}
+
+.has-warning input {
+  border-color: rgba(201, 122, 30, 0.65);
+  box-shadow: 0 0 0 3px rgba(201, 122, 30, 0.2);
+}
+
+.has-success input {
+  border-color: rgba(36, 159, 127, 0.65);
+  box-shadow: 0 0 0 3px rgba(36, 159, 127, 0.2);
+}
+
+.field-error,
+.field-warning,
+.field-success {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.field-error { color: var(--storybook-critical); }
+.field-warning { color: var(--storybook-warning); }
+.field-success { color: var(--storybook-success); }
+
+.filter-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.filter-chip {
+  border-radius: 999px;
+  border: 1px solid var(--storybook-border);
+  padding: 0.35rem 0.85rem;
+  background: #fff;
+  color: var(--storybook-text-strong);
+  font-size: 0.85rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  cursor: pointer;
+  transition: background 140ms ease, border-color 140ms ease;
+}
+
+.filter-chip.active {
+  background: rgba(46, 90, 172, 0.1);
+  border-color: var(--storybook-primary);
+  color: var(--storybook-primary);
+}
+
+.filter-chip i {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(-45deg);
+}
+
+/* Overlays */
+.modal-preview {
+  background: rgba(17, 24, 39, 0.04);
+  padding: 2rem;
+  border-radius: var(--storybook-radius-md);
+  display: flex;
+  justify-content: center;
+}
+
+.modal-window {
+  width: min(520px, 100%);
+  background: #fff;
+  border-radius: 12px;
+  border: 1px solid var(--storybook-border);
+  box-shadow: 0 24px 48px rgba(17, 24, 39, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.75rem;
+}
+
+.modal-window header h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.modal-window header .modal-meta {
+  color: var(--storybook-text-muted);
+  font-size: 0.85rem;
+}
+
+.modal-body {
+  color: var(--storybook-text-muted);
+  font-size: 0.95rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modal-checklist {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.modal-window footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.slideover-preview {
+  background: rgba(17, 24, 39, 0.04);
+  border-radius: var(--storybook-radius-md);
+  padding: 1.5rem;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.slideover {
+  width: min(360px, 100%);
+  background: #fff;
+  border: 1px solid var(--storybook-border);
+  border-radius: 16px 0 0 16px;
+  box-shadow: 0 20px 40px rgba(17, 24, 39, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.5rem;
+}
+
+.slideover header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.slideover h3 {
+  margin: 0;
+}
+
+.slideover-close {
+  border: none;
+  background: rgba(17, 24, 39, 0.06);
+  border-radius: 999px;
+  width: 32px;
+  height: 32px;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.slideover-body dl {
+  display: grid;
+  gap: 1rem;
+  margin: 0;
+}
+
+.slideover-body dt {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--storybook-text-muted);
+}
+
+.slideover-body dd {
+  margin: 0.25rem 0 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.slideover footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.toast-stack {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.toast {
+  background: #fff;
+  border-radius: var(--storybook-radius-md);
+  border-left: 4px solid var(--storybook-primary);
+  padding: 0.9rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  box-shadow: 0 12px 24px rgba(17, 24, 39, 0.12);
+}
+
+.toast strong {
+  font-size: 0.95rem;
+}
+
+.toast span {
+  font-size: 0.85rem;
+  color: var(--storybook-text-muted);
+}
+
+.toast.success { border-left-color: var(--storybook-success); }
+.toast.warning { border-left-color: var(--storybook-warning); }
+.toast.critical { border-left-color: var(--storybook-critical); }
+
+/* Visualizations */
+.viz-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
+}
+
+.viz-card {
+  background: #fff;
+  border: 1px solid var(--storybook-border);
+  border-radius: var(--storybook-radius-md);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  box-shadow: 0 12px 24px rgba(17, 24, 39, 0.08);
+}
+
+.viz-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.viz-card footer {
+  font-size: 0.85rem;
+  color: var(--storybook-text-muted);
+}
+
+.sparkline svg {
+  width: 100%;
+  height: 48px;
+}
+
+.sparkline polyline {
+  fill: none;
+  stroke: var(--storybook-primary);
+  stroke-width: 4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.capacity-ring svg {
+  width: 120px;
+  height: 120px;
+}
+
+.capacity-ring circle {
+  fill: none;
+  stroke-width: 12;
+  stroke-linecap: round;
+}
+
+.capacity-ring circle.bg {
+  stroke: rgba(17, 24, 39, 0.08);
+}
+
+.capacity-ring circle.fg {
+  stroke: var(--storybook-success);
+  transform: rotate(-90deg);
+  transform-origin: 50% 50%;
+}
+
+.capacity-ring text {
+  font-size: 1.15rem;
+  font-weight: 700;
+  fill: var(--storybook-text-strong);
+}
+
+.segmented-bar {
+  display: flex;
+  border-radius: var(--storybook-radius-sm);
+  overflow: hidden;
+  border: 1px solid var(--storybook-border);
+}
+
+.segmented-bar .segment {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--storybook-text-strong);
+  padding: 0.4rem 0.5rem;
+  min-width: 0;
+  flex: 0 0 auto;
+  width: var(--segment);
+}
+
+.segment.ready { background: rgba(36, 159, 127, 0.2); }
+.segment.staging { background: rgba(46, 90, 172, 0.12); }
+.segment.hold { background: rgba(199, 62, 62, 0.18); }
+
+@media (max-width: 680px) {
+  .playground-shell {
+    box-shadow: none;
+    border-radius: 0;
+  }
+  .playground-stage {
+    padding: 1.5rem;
+  }
+}

--- a/src/main/resources/templates/admin/bar.html
+++ b/src/main/resources/templates/admin/bar.html
@@ -1,36 +1,79 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-  <head>
-    <meta charset="UTF-8"/>
-    <title>Bar Admin</title>
-    <link rel="stylesheet" th:href="@{/css/app.css}"/>
-  </head>
-  <body>
-    <header>
-      <h1>Bar Admin</h1>
-    </header>
-    <main>
-      <h2>Your Taps</h2>
-      <table>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="layouts/app :: layout('Bar Operations', 'bar', 'Live view of tap health and keg status for this bar location.', ~{::section[@id='page-content']})">
+<section id="page-content">
+  <section class="page-section">
+    <div class="card-grid">
+      <article class="metric-card">
+        <header>
+          <h3>Assigned taps</h3>
+          <span class="metric-pill success" th:text="${tapCount} + ' total'">0 total</span>
+        </header>
+        <div class="metric-value" th:text="${tapCount}">0</div>
+        <footer class="muted">Tap handles linked to this bar.</footer>
+      </article>
+      <article class="metric-card">
+        <header>
+          <h3>On tap now</h3>
+          <span class="metric-pill warning" th:text="${activeTapCount} + ' pouring'">0 pouring</span>
+        </header>
+        <div class="metric-value" th:text="${activeTapCount}">0</div>
+        <footer class="muted">Taps with a keg currently online.</footer>
+      </article>
+      <article class="metric-card">
+        <header>
+          <h3>Low alerts</h3>
+          <span class="metric-pill critical" th:text="${lowTapAlertCount} + ' watching'">0 watching</span>
+        </header>
+        <div class="metric-value" th:text="${lowTapAlertCount}">0</div>
+        <footer class="muted">Kegs at or below 10% capacity.</footer>
+      </article>
+    </div>
+  </section>
+
+  <section class="page-section">
+    <div class="section-heading">
+      <div>
+        <h2>Tapline status</h2>
+        <p class="muted">Monitor pours and refill low-volume kegs.</p>
+      </div>
+      <div class="actions">
+        <a class="btn ghost" th:href="@{/taplist}">View guest-facing taplist</a>
+      </div>
+    </div>
+
+    <div class="table-wrapper">
+      <table class="table">
         <thead>
           <tr>
-            <th>#</th>
+            <th>Tap</th>
             <th>Beer</th>
-            <th>%</th>
+            <th>Fill</th>
           </tr>
         </thead>
         <tbody>
-          <tr th:each="t : ${taps}">
+          <tr th:each="t : ${taps}" th:classappend="${t.keg != null && t.keg.fillPercent != null && t.keg.fillPercent <= 10} ? 'is-low' : ''">
             <td th:text="${t.number}">1</td>
             <td>
-              <span th:if="${t.keg != null}" th:text="${t.keg.beer.name}">Beer</span>
-              <span th:if="${t.keg == null}"><em>Empty</em></span>
+              <span th:if="${t.keg != null}">
+                <strong th:text="${t.keg.beer.name}">Beer</strong>
+                <span class="muted" th:text="${t.keg.beer.style != null ? ' · ' + t.keg.beer.style : ''}">Style</span>
+              </span>
+              <span th:if="${t.keg == null}" class="muted">Empty</span>
             </td>
-            <td th:text="${t.keg != null ? t.keg.fillPercent : 0}">0</td>
+            <td>
+              <div th:if="${t.keg != null}" class="fillbar">
+                <div class="fill" th:style="${'width:' + t.keg.fillPercent + '%'}"></div>
+              </div>
+              <span class="muted" th:text="${t.keg != null ? t.keg.fillPercent + '%' : '-'}">%</span>
+            </td>
+          </tr>
+          <tr th:if="${#lists.isEmpty(taps)}">
+            <td colspan="3" class="muted">No taps registered for this bar.</td>
           </tr>
         </tbody>
       </table>
-    </main>
-    <div th:replace="~{fragments/footer :: footer}"></div>
-  </body>
+    </div>
+  </section>
+</section>
 </html>

--- a/src/main/resources/templates/admin/beer.html
+++ b/src/main/resources/templates/admin/beer.html
@@ -1,72 +1,117 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-<head>
-  <meta charset="UTF-8"/>
-  <title>Beers — Link BJCP Style</title>
-  <link rel="stylesheet" th:href="@{/css/app.css}"/>
-</head>
-<body>
-<header>
-  <h1>Beers — Link BJCP Style</h1>
-  <p><a class="btn ghost" th:href="@{/admin/brewery}">⟵ Back to Brewery Admin</a></p>
-</header>
-<main>
-  <form method="get" th:action="@{/admin/beer}" class="inline" style="margin-bottom:.5rem">
-    <label>Guideline Year
-      <select name="year">
-        <option th:value="2015" th:selected="${year == 2015}">2015</option>
-        <option th:value="2021" th:selected="${year == 2021}">2021</option>
-      </select>
-    </label>
-    <label style="margin-left:.5rem">Search Beers
-      <input type="text" name="q" placeholder="beer name…" th:value="${q}"/>
-    </label>
-    <button class="btn" type="submit">Apply</button>
-  </form>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="layouts/app :: layout('Beer Library', 'beer', 'Link brewery beers to BJCP guidelines and keep style metadata current.', ~{::section[@id='page-content']})">
+<section id="page-content">
+  <section class="page-section">
+    <div class="card-grid">
+      <article class="metric-card">
+        <header>
+          <h3>Beers in scope</h3>
+          <span class="metric-pill success" th:text="${beerCount} + ' total'">0 total</span>
+        </header>
+        <div class="metric-value" th:text="${beerCount}">0</div>
+        <footer class="muted">Distinct beers associated with your brewery.</footer>
+      </article>
+      <article class="metric-card">
+        <header>
+          <h3>Style linked</h3>
+          <span class="metric-pill warning" th:text="${linkedBeerCount} + ' mapped'">0 mapped</span>
+        </header>
+        <div class="metric-value" th:text="${linkedBeerCount}">0</div>
+        <footer class="muted">Uses BJCP reference for style normalization.</footer>
+      </article>
+      <article class="metric-card">
+        <header>
+          <h3>Style options</h3>
+          <span class="metric-pill info" th:text="${styleOptionCount} + ' entries'">0 entries</span>
+        </header>
+        <div class="metric-value" th:text="${styleCategoryCount}">0</div>
+        <footer class="muted">BJCP categories available for mapping.</footer>
+      </article>
+    </div>
+  </section>
 
-  <table class="table">
-    <thead>
-    <tr>
-      <th>Name</th>
-      <th>Current Style (text)</th>
-      <th>BJCP Style</th>
-      <th>Linked</th>
-      <th>Action</th>
-    </tr>
-    </thead>
-    <tbody>
-    <tr th:each="b : ${beers}">
-      <td th:text="${b.name}">Beer</td>
-      <td th:text="${b.style}">Style</td>
-      <td>
-        <form method="post" th:action="@{'/admin/beer/' + ${b.id} + '/style'}" class="inline">
-          <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-          <input type="hidden" name="year" th:value="${year}"/>
-          <select name="styleId" required>
-            <option value="" disabled selected>Select BJCP style…</option>
-            <optgroup th:each="entry : ${stylesByCategory}" th:label="${entry.key}">
-              <option th:each="s : ${entry.value}" th:value="${s.id}" th:text="${s.code + ' — ' + s.name}">
-              </option>
-            </optgroup>
-          </select>
-          <button class="btn" type="submit">Link</button>
-        </form>
-      </td>
-      <td>
-        <span th:if="${b.styleRef != null}" th:text="${b.styleRef.code + ' — ' + b.styleRef.name}">18B — APA</span>
-        <span th:if="${b.styleRef == null}">-</span>
-      </td>
-      <td class="actions">
-        <form th:if="${b.styleRef != null}" method="post" th:action="@{'/admin/beer/' + ${b.id} + '/style/unlink'}" class="inline">
-          <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-          <input type="hidden" name="year" th:value="${year}"/>
-          <button class="btn danger" type="submit">Unlink</button>
-        </form>
-      </td>
-    </tr>
-    </tbody>
-  </table>
-</main>
-<div th:replace="~{fragments/footer :: footer}"></div>
-</body>
+  <section class="page-section">
+    <div class="section-heading">
+      <div>
+        <h2>Manage BJCP linkage</h2>
+        <p class="muted">Filter your library, assign guideline codes, and keep metadata in sync.</p>
+      </div>
+      <div class="actions">
+        <a class="btn ghost" th:href="@{/admin/brewery}">Back to brewery admin</a>
+      </div>
+    </div>
+
+    <form method="get" th:action="@{/admin/beer}" class="form-inline">
+      <div class="form-group">
+        <label for="guidelineYear">Guideline year</label>
+        <select id="guidelineYear" name="year">
+          <option th:value="2015" th:selected="${year == 2015}">2015</option>
+          <option th:value="2021" th:selected="${year == 2021}">2021</option>
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="beerSearch">Search beers</label>
+        <input id="beerSearch" type="text" name="q" placeholder="Beer name…" th:value="${q}" />
+      </div>
+      <div class="form-actions">
+        <button class="btn primary" type="submit">Apply filters</button>
+      </div>
+    </form>
+
+    <div class="table-wrapper">
+      <table class="table">
+        <thead>
+        <tr>
+          <th>Name</th>
+          <th>Declared style</th>
+          <th>BJCP link</th>
+          <th>Current mapping</th>
+          <th aria-label="Actions"></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="b : ${beers}">
+          <td th:text="${b.name}">Beer</td>
+          <td th:text="${b.style}">Style</td>
+          <td>
+            <form method="post" th:action="@{'/admin/beer/' + ${b.id} + '/style'}" class="form-inline form-inline--compact">
+              <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+              <input type="hidden" name="year" th:value="${year}" />
+              <div class="form-group">
+                <label class="sr-only" th:for="${'style-' + b.id}">BJCP style</label>
+                <select th:id="${'style-' + b.id}" name="styleId" required>
+                  <option value="" disabled selected>Select BJCP style…</option>
+                  <optgroup th:each="entry : ${stylesByCategory}" th:label="${entry.key}">
+                    <option th:each="s : ${entry.value}" th:value="${s.id}" th:text="${s.code + ' — ' + s.name}"></option>
+                  </optgroup>
+                </select>
+              </div>
+              <div class="form-actions">
+                <button class="btn secondary" type="submit">Link style</button>
+              </div>
+            </form>
+          </td>
+          <td>
+            <span th:if="${b.styleRef != null}" th:text="${b.styleRef.code + ' — ' + b.styleRef.name}">18B — APA</span>
+            <span th:if="${b.styleRef == null}" class="muted">Not linked</span>
+          </td>
+          <td class="actions">
+            <form th:if="${b.styleRef != null}" method="post" th:action="@{'/admin/beer/' + ${b.id} + '/style/unlink'}" class="form-inline form-inline--compact">
+              <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+              <input type="hidden" name="year" th:value="${year}" />
+              <div class="form-actions">
+                <button class="btn critical outline" type="submit">Unlink</button>
+              </div>
+            </form>
+          </td>
+        </tr>
+        <tr th:if="${#lists.isEmpty(beers)}">
+          <td class="muted" colspan="5">No beers found for the selected filters.</td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</section>
 </html>

--- a/src/main/resources/templates/admin/brewery.html
+++ b/src/main/resources/templates/admin/brewery.html
@@ -1,284 +1,422 @@
-
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-<head><meta charset="UTF-8"/><title>Brewery Admin</title><link rel="stylesheet" th:href="@{/css/app.css}"/></head>
-<body>
-<header><h1>Brewery Admin</h1></header>
-<main>
-  <!-- Brewery info always at top -->
-  <section>
-    <h2 th:text="${brewery != null ? brewery.name : 'Your Brewery'}">Your Brewery</h2>
-    <form method="post" action="#" th:action="@{/admin/brewery/updateInfo}" class="inline">
-      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-      <label>Name <input type="text" name="name" th:value="${brewery != null ? brewery.name : ''}"/></label>
-      <button class="btn" type="submit">Save</button>
-    </form>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="layouts/app :: layout('Brewery Operations', 'brewery', 'Coordinate taprooms, kegs, and distribution for this brewery.', ~{::section[@id='page-content']})">
+<section id="page-content">
+  <section class="page-section">
+    <div class="card-grid">
+      <article class="metric-card">
+        <header>
+          <h3>Taprooms</h3>
+          <span class="metric-pill success" th:text="${taproomCount} + ' active'">0 active</span>
+        </header>
+        <div class="metric-value" th:text="${taproomCount}">0</div>
+        <footer class="muted">Taprooms linked to this brewery.</footer>
+      </article>
+      <article class="metric-card">
+        <header>
+          <h3>Active tap handles</h3>
+          <span class="metric-pill warning" th:text="${activeTapHandles} + ' pouring'">0 pouring</span>
+        </header>
+        <div class="metric-value" th:text="${activeTapHandles}">0</div>
+        <footer class="muted">Live draft lines reporting a keg.</footer>
+      </article>
+      <article class="metric-card">
+        <header>
+          <h3>Available kegs</h3>
+          <span class="metric-pill info" th:text="${availableKegCount} + ' in house'">0 in house</span>
+        </header>
+        <div class="metric-value" th:text="${availableKegCount}">0</div>
+        <footer class="muted">Unassigned, brewery-controlled inventory.</footer>
+      </article>
+      <article class="metric-card">
+        <header>
+          <h3>Distributed / Returned</h3>
+          <span class="metric-pill critical" th:text="${distributedKegCount} + ' out'">0 out</span>
+        </header>
+        <div class="metric-value" th:text="${returnedKegCount}">0</div>
+        <footer class="muted">Returned kegs ready for cleaning.</footer>
+      </article>
+      <article class="metric-card">
+        <header>
+          <h3>Team members</h3>
+          <span class="metric-pill info" th:text="${breweryUserCount} + ' accounts'">0 accounts</span>
+        </header>
+        <div class="metric-value" th:text="${breweryUserCount}">0</div>
+        <footer class="muted">Users scoped to this brewery &amp; venues.</footer>
+      </article>
+    </div>
   </section>
 
-  <!-- Tabs below general information -->
-  <div class="tabs">
-    <a th:classappend="${(tab == null or tab == 'taprooms') ? ' active' : ''}"
-       th:href="@{/admin/brewery(tab='taprooms')}">Taprooms</a>
-    <a th:classappend="${(tab == 'kegs') ? ' active' : ''}"
-       th:href="@{/admin/brewery(tab='kegs')}">Kegs</a>
-    <a th:classappend="${(tab == 'assigned') ? ' active' : ''}"
-       th:href="@{/admin/brewery(tab='assigned')}">Assigned Kegs</a>
-    <a th:classappend="${(tab == 'returned') ? ' active' : ''}"
-       th:href="@{/admin/brewery(tab='returned')}">Returned Kegs</a>
-    <a th:classappend="${(tab == 'users') ? ' active' : ''}"
-       th:href="@{/admin/brewery(tab='users')}">Users</a>
-    <a th:href="@{/admin/beer}">Beers</a>
-    <a th:classappend="${(tab == 'catalog') ? ' active' : ''}"
-       th:href="@{/admin/brewery(tab='catalog')}">Catalog</a>
-  </div>
+  <section class="page-section">
+    <div class="section-heading">
+      <div>
+        <h2 th:text="${brewery != null ? brewery.name : 'Brewery'}">Brewery</h2>
+        <p class="muted">Update core details and switch between operational tabs.</p>
+      </div>
+      <div class="actions">
+        <a class="btn ghost" th:href="@{/admin/site}">Back to control center</a>
+      </div>
+    </div>
 
-  <section th:if="${tab == null or tab == 'taprooms'}">
-    <h2>Your Taprooms</h2>
-    <form method="get" th:action="@{/admin/brewery}" class="inline" style="margin-bottom:.5rem">
-      <input type="hidden" name="tab" value="taprooms"/>
-      <input name="q" placeholder="Search taprooms..." th:value="${q}"/>
-      <button class="btn" type="submit">Search</button>
+    <form method="post" th:action="@{/admin/brewery/updateInfo}" class="form-inline">
+      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+      <div class="form-group">
+        <label for="breweryName">Name</label>
+        <input id="breweryName" type="text" name="name" required th:value="${brewery != null ? brewery.name : ''}" />
+      </div>
+      <div class="form-actions">
+        <button class="btn primary" type="submit">Save changes</button>
+      </div>
     </form>
-    <form method="post" th:action="@{/admin/brewery/taprooms/add}" class="inline" style="margin-left:.5rem">
-      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-      <label>New taproom name <input type="text" name="name" required/></label>
-      <button class="btn" type="submit">Add Taproom</button>
-    </form>
-    <table class="table">
-      <thead><tr><th>Name</th><th>Taps</th><th>Active Kegs</th><th class="actions">Actions</th></tr></thead>
-      <tbody>
-      <tr th:each="t : ${taprooms}">
-        <td th:text="${t.name}">Taproom</td>
-        <td th:text="${tapsByTaproom[t.id] != null ? tapsByTaproom[t.id].size() : 0}">0</td>
-        <td th:text="${activeKegsByTaproom[t.id] != null ? activeKegsByTaproom[t.id] : 0}">0</td>
-        <td class="actions">
-          <a class="btn" th:href="@{/admin/taproom(taproomId=${t.id},from='brewery')}">Admin</a>
-          <form method="post" class="inline" th:action="@{'/admin/brewery/taprooms/' + ${t.id} + '/delete'}">
-            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-            <button class="btn danger" type="submit">Remove</button>
-          </form>
-        </td>
-      </tr>
-      </tbody>
-    </table>
+
+    <div class="tabs">
+      <a th:href="@{/admin/brewery(tab='taprooms')}"
+         th:classappend="${tab == null or tab == 'taprooms'} ? ' active' : ''">Taprooms</a>
+      <a th:href="@{/admin/brewery(tab='kegs')}"
+         th:classappend="${tab == 'kegs'} ? ' active' : ''">Kegs</a>
+      <a th:href="@{/admin/brewery(tab='assigned')}"
+         th:classappend="${tab == 'assigned'} ? ' active' : ''">Assigned</a>
+      <a th:href="@{/admin/brewery(tab='returned')}"
+         th:classappend="${tab == 'returned'} ? ' active' : ''">Returned</a>
+      <a th:href="@{/admin/brewery(tab='users')}"
+         th:classappend="${tab == 'users'} ? ' active' : ''">Users</a>
+      <a th:href="@{/admin/brewery(tab='catalog')}"
+         th:classappend="${tab == 'catalog'} ? ' active' : ''">Catalog</a>
+    </div>
   </section>
 
-  <section th:if="${tab == 'kegs'}">
-  <h2>Kegs (Unassigned at Brewery)</h2>
-  <div class="filters">
-    <span>Status:</span>
-    <a th:href="@{/admin/brewery(tab='kegs')}" th:classappend="${(selectedStatus == null) ? ' chip active' : ' chip'}">All</a>
-    <a th:each="s : ${allStatuses}"
-       th:href="@{/admin/brewery(tab='kegs', status=${s})}"
-       th:text="${s}"
-       th:classappend="${(selectedStatus == s) ? ' chip active' : ' chip'}">FILLED</a>
-  </div>
+  <section class="page-section" th:if="${tab == null or tab == 'taprooms'}">
+    <div class="section-heading">
+      <div>
+        <h3>Taproom coverage</h3>
+        <p class="muted">Search, manage, and jump into individual taproom consoles.</p>
+      </div>
+    </div>
 
-  <table class="table">
-    <thead>
-      <tr>
-        <th>Serial</th>
-        <th>Beer</th>
-        <th>Size</th>
-        <th>Status</th>
-        <th>Assigned Venue</th>
-        <th>Distribute</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr th:each="k : ${kegs}">
-        <td th:text="${k.serialNumber}">SER-001</td>
-        <td th:text="${k.beer != null ? k.beer.name : '-'}">Beer</td>
-        <td th:text="${k.size}">HALF_BARREL</td>
-        <td>
-          <th:block th:switch="${k.status}">
-            <span class="badge green" th:case="${T(com.mythictales.bms.taplist.domain.KegStatus).FILLED}"
-                  th:text="${k.status}"></span>
-            <span class="badge blue" th:case="${T(com.mythictales.bms.taplist.domain.KegStatus).DISTRIBUTED}"
-                  th:text="${k.status}"></span>
-            <span class="badge purple" th:case="${T(com.mythictales.bms.taplist.domain.KegStatus).RECEIVED}"
-                  th:text="${k.status}"></span>
-            <span class="badge orange" th:case="${T(com.mythictales.bms.taplist.domain.KegStatus).TAPPED}"
-                  th:text="${k.status}"></span>
-            <span class="badge red" th:case="${T(com.mythictales.bms.taplist.domain.KegStatus).BLOWN}"
-                  th:text="${k.status}"></span>
-            <span class="badge gray" th:case="*" th:text="${k.status}"></span>
-          </th:block>
-        </td>
-        <td th:text="${k.assignedVenue != null ? k.assignedVenue.name : '-'}">-</td>
-        <td>
-          <form method="post" th:action="@{'/admin/brewery/kegs/' + ${k.id} + '/distribute'}">
-            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-            <select name="venueId" required>
-              <option value="" disabled selected>Select venue…</option>
-              <option th:each="v : ${venues}" th:value="${v.id}" th:text="${v.name}">Venue</option>
-            </select>
-            <button class="btn" type="submit">Distribute</button>
-          </form>
-          <form method="post" th:action="@{'/admin/brewery/kegs/' + ${k.id} + '/clean'}" class="inline" style="margin-left:.5rem;">
-            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-            <button class="btn" type="submit">Mark Clean</button>
-          </form>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-  </section>
+    <div class="stacked-forms">
+      <form method="get" th:action="@{/admin/brewery}" class="form-inline">
+        <input type="hidden" name="tab" value="taprooms" />
+        <div class="form-group">
+          <label for="taproomSearch">Search taprooms</label>
+          <input id="taproomSearch" name="q" placeholder="Taproom name…" th:value="${q}" />
+        </div>
+        <div class="form-actions">
+          <button class="btn secondary" type="submit">Search</button>
+        </div>
+      </form>
 
-  <section th:if="${tab == 'users'}">
-    <h2>Users</h2>
-    <form method="get" action="/admin/brewery" class="inline">
-      <input type="hidden" name="tab" value="users"/>
-      <label>Filter by Venue
-        <select name="userVenueId">
-          <option value="">All</option>
-          <option th:each="v : ${venues}" th:value="${v.id}" th:text="${v.name}"
-                  th:selected="${userVenueId} == ${v.id}">Venue</option>
-        </select>
-      </label>
-      <button class="btn" type="submit">Apply</button>
-    </form>
-    <table class="table">
-      <thead>
-        <tr><th>Username</th><th>Role</th><th>Brewery</th><th>Taproom</th><th>Bar</th></tr>
-      </thead>
-      <tbody>
-        <tr th:each="u : ${breweryUsers}">
-          <td th:text="${u.username}">user</td>
-          <td th:text="${u.role}">role</td>
-          <td th:text="${u.brewery != null ? u.brewery.name : '-'}">-</td>
-          <td th:text="${u.taproom != null ? u.taproom.name : '-'}">-</td>
-          <td th:text="${u.bar != null ? u.bar.name : '-'}">-</td>
+      <form method="post" th:action="@{/admin/brewery/taprooms/add}" class="form-inline">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+        <div class="form-group">
+          <label for="newTaproomName">Add taproom</label>
+          <input id="newTaproomName" type="text" name="name" placeholder="Taproom name" required />
+        </div>
+        <div class="form-actions">
+          <button class="btn primary" type="submit">Add taproom</button>
+        </div>
+      </form>
+    </div>
+
+    <div class="table-wrapper">
+      <table class="table">
+        <thead>
+        <tr>
+          <th>Name</th>
+          <th>Taps</th>
+          <th>Active kegs</th>
+          <th aria-label="Actions"></th>
         </tr>
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+        <tr th:each="t : ${taprooms}">
+          <td th:text="${t.name}">Taproom</td>
+          <td th:text="${tapsByTaproom[t.id] != null ? tapsByTaproom[t.id].size() : 0}">0</td>
+          <td th:text="${activeKegsByTaproom[t.id] != null ? activeKegsByTaproom[t.id] : 0}">0</td>
+          <td class="actions">
+            <a class="btn ghost" th:href="@{/admin/taproom(taproomId=${t.id},from='brewery')}" th:text="${'Manage'}">Manage</a>
+            <form method="post" th:action="@{'/admin/brewery/taprooms/' + ${t.id} + '/delete'}" class="form-inline form-inline--compact">
+              <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+              <div class="form-actions">
+                <button class="btn critical outline" type="submit">Remove</button>
+              </div>
+            </form>
+          </td>
+        </tr>
+        <tr th:if="${#lists.isEmpty(taprooms)}">
+          <td class="muted" colspan="4">No taprooms connected yet.</td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
   </section>
 
-  <section th:if="${tab == 'assigned'}">
-    <h2>Assigned Kegs (Sent to Venues)</h2>
-    <div class="filters" style="margin-bottom:.5rem">
-      <span>Status:</span>
+  <section class="page-section" th:if="${tab == 'kegs'}">
+    <div class="section-heading">
+      <div>
+        <h3>In-house kegs</h3>
+        <p class="muted">Filter brewery-controlled inventory and distribute to venues.</p>
+      </div>
+    </div>
+
+    <div class="filter-chip-row">
+      <span class="muted">Status:</span>
+      <a th:href="@{/admin/brewery(tab='kegs')}"
+         th:classappend="${selectedStatus == null} ? ' filter-chip active' : ' filter-chip'">All</a>
+      <a th:each="s : ${allStatuses}"
+         th:href="@{/admin/brewery(tab='kegs', status=${s})}"
+         th:text="${s}"
+         th:classappend="${selectedStatus == s} ? ' filter-chip active' : ' filter-chip'">FILLED</a>
+    </div>
+
+    <div class="table-wrapper">
+      <table class="table">
+        <thead>
+        <tr>
+          <th>Serial</th>
+          <th>Beer</th>
+          <th>Size</th>
+          <th>Status</th>
+          <th>Assigned venue</th>
+          <th aria-label="Actions"></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="k : ${kegs}">
+          <td th:text="${k.serialNumber}">SER-001</td>
+          <td th:text="${k.beer != null ? k.beer.name : '-'}">Beer</td>
+          <td th:text="${k.size}">HALF_BARREL</td>
+          <td>
+            <span class="badge"
+                  th:classappend="${k.status == T(com.mythictales.bms.taplist.domain.KegStatus).FILLED} ? ' green' :
+                                  (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).DISTRIBUTED ? ' blue' :
+                                  (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).RECEIVED ? ' purple' :
+                                  (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).TAPPED ? ' orange' :
+                                  (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).BLOWN ? ' red' : ' gray'))))" 
+                  th:text="${k.status}">FILLED</span>
+          </td>
+          <td th:text="${k.assignedVenue != null ? k.assignedVenue.name : '-'}">-</td>
+          <td class="actions">
+            <form method="post" th:action="@{'/admin/brewery/kegs/' + ${k.id} + '/distribute'}" class="form-inline form-inline--compact">
+              <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+              <div class="form-group">
+                <label class="sr-only" th:for="${'venue-' + k.id}">Select venue</label>
+                <select th:id="${'venue-' + k.id}" name="venueId" required>
+                  <option value="" disabled selected>Select venue…</option>
+                  <option th:each="v : ${venues}" th:value="${v.id}" th:text="${v.name}">Venue</option>
+                </select>
+              </div>
+              <div class="form-actions">
+                <button class="btn secondary" type="submit">Distribute</button>
+              </div>
+            </form>
+            <form method="post" th:action="@{'/admin/brewery/kegs/' + ${k.id} + '/clean'}" class="form-inline form-inline--compact">
+              <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+              <div class="form-actions">
+                <button class="btn ghost" type="submit">Mark clean</button>
+              </div>
+            </form>
+          </td>
+        </tr>
+        <tr th:if="${#lists.isEmpty(kegs)}">
+          <td class="muted" colspan="6">No kegs match the selected filter.</td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="page-section" th:if="${tab == 'assigned'}">
+    <div class="section-heading">
+      <div>
+        <h3>Assigned to venues</h3>
+        <p class="muted">Track distributed kegs and recall when needed.</p>
+      </div>
+    </div>
+
+    <div class="filter-chip-row">
+      <span class="muted">Status:</span>
       <a th:href="@{/admin/brewery(tab='assigned', assignedVenueId=${assignedVenueId})}"
-         th:classappend="${(selectedStatus == null) ? ' chip active' : ' chip'}">All</a>
+         th:classappend="${selectedStatus == null} ? ' filter-chip active' : ' filter-chip'">All</a>
       <a th:each="s : ${allStatuses}"
          th:href="@{/admin/brewery(tab='assigned', status=${s}, assignedVenueId=${assignedVenueId})}"
          th:text="${s}"
-         th:classappend="${(selectedStatus == s) ? ' chip active' : ' chip'}">FILLED</a>
+         th:classappend="${selectedStatus == s} ? ' filter-chip active' : ' filter-chip'">FILLED</a>
     </div>
 
-    <form method="get" th:action="@{/admin/brewery}" class="inline" style="margin-bottom:.5rem">
-      <input type="hidden" name="tab" value="assigned"/>
-      <input type="hidden" name="status" th:value="${selectedStatus}"/>
-      <label>Filter by Venue
-        <select name="assignedVenueId">
-          <option value="">All</option>
+    <form method="get" th:action="@{/admin/brewery}" class="form-inline">
+      <input type="hidden" name="tab" value="assigned" />
+      <input type="hidden" name="status" th:value="${selectedStatus}" />
+      <div class="form-group">
+        <label for="assignedVenue">Filter by venue</label>
+        <select id="assignedVenue" name="assignedVenueId">
+          <option value="">All venues</option>
           <option th:each="v : ${venues}" th:value="${v.id}" th:text="${v.name}"
                   th:selected="${assignedVenueId} == ${v.id}">Venue</option>
         </select>
-      </label>
-      <button class="btn" type="submit">Apply</button>
+      </div>
+      <div class="form-actions">
+        <button class="btn secondary" type="submit">Apply</button>
+      </div>
     </form>
-    <table class="table">
-      <thead>
+
+    <div class="table-wrapper">
+      <table class="table">
+        <thead>
         <tr>
-          <th>Serial</th><th>Beer</th><th>Size</th><th>Status</th><th>Venue</th><th>Return</th>
+          <th>Serial</th>
+          <th>Beer</th>
+          <th>Size</th>
+          <th>Status</th>
+          <th>Venue</th>
+          <th aria-label="Actions"></th>
         </tr>
-      </thead>
-      <tbody>
+        </thead>
+        <tbody>
         <tr th:each="k : ${assignedKegs}">
           <td th:text="${k.serialNumber}">SER-020</td>
           <td th:text="${k.beer != null ? k.beer.name : '-'}">Beer</td>
           <td th:text="${k.size}">SIXTEL</td>
           <td>
-            <th:block th:switch="${k.status}">
-              <span class="badge green" th:case="${T(com.mythictales.bms.taplist.domain.KegStatus).FILLED}"
-                    th:text="${k.status}"></span>
-              <span class="badge blue" th:case="${T(com.mythictales.bms.taplist.domain.KegStatus).DISTRIBUTED}"
-                    th:text="${k.status}"></span>
-              <span class="badge purple" th:case="${T(com.mythictales.bms.taplist.domain.KegStatus).RECEIVED}"
-                    th:text="${k.status}"></span>
-              <span class="badge orange" th:case="${T(com.mythictales.bms.taplist.domain.KegStatus).TAPPED}"
-                    th:text="${k.status}"></span>
-              <span class="badge red" th:case="${T(com.mythictales.bms.taplist.domain.KegStatus).BLOWN}"
-                    th:text="${k.status}"></span>
-              <span class="badge gray" th:case="*" th:text="${k.status}"></span>
-            </th:block>
+            <span class="badge"
+                  th:classappend="${k.status == T(com.mythictales.bms.taplist.domain.KegStatus).FILLED} ? ' green' :
+                                  (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).DISTRIBUTED ? ' blue' :
+                                  (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).RECEIVED ? ' purple' :
+                                  (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).TAPPED ? ' orange' :
+                                  (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).BLOWN ? ' red' : ' gray'))))"
+                  th:text="${k.status}">FILLED</span>
           </td>
-          <td th:text="${k.assignedVenue != null ? k.assignedVenue.name : '-'}">-</td>
-          <td>
-            <form method="post" th:action="@{'/admin/brewery/kegs/' + ${k.id} + '/return'}">
-              <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-              <button class="btn" type="submit">Return</button>
+          <td th:text="${k.assignedVenue != null ? k.assignedVenue.name : '-'}">Venue</td>
+          <td class="actions">
+            <form method="post" th:action="@{'/admin/brewery/kegs/' + ${k.id} + '/return'}" class="form-inline form-inline--compact">
+              <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+              <div class="form-actions">
+                <button class="btn ghost" type="submit">Mark returned</button>
+              </div>
             </form>
           </td>
         </tr>
-      </tbody>
-    </table>
+        <tr th:if="${#lists.isEmpty(assignedKegs)}">
+          <td class="muted" colspan="6">No distributed kegs match the filters.</td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
   </section>
 
-  <section th:if="${tab == 'returned'}">
-    <h2>Returned Kegs</h2>
-    <table class="table">
-      <thead>
-        <tr>
-          <th>Serial</th><th>Beer</th><th>Size</th><th>Status</th><th>Reset</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr th:each="k : ${returnedKegs}">
-          <td th:text="${k.serialNumber}">SER-100</td>
-          <td th:text="${k.beer != null ? k.beer.name : '-'}">Beer</td>
-          <td th:text="${k.size}">SIXTEL</td>
-          <td th:text="${k.status}">RETURNED</td>
-          <td>
-            <form method="post" th:action="@{'/admin/brewery/kegs/' + ${k.id} + '/return'}">
-              <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-              <button class="btn" type="submit">Reset to Empty</button>
-            </form>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </section>
-
-  <section th:if="${tab == 'catalog'}">
-    <h2>Catalog</h2>
-    <div style="display:flex; gap: .75rem; align-items:center; margin-bottom:.75rem; flex-wrap: wrap;">
-      <a class="btn ghost" th:href="@{/admin/beer}">Link BJCP Styles</a>
-      <form method="post" enctype="multipart/form-data" th:action="@{/api/v1/catalog/recipes/import}">
-        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-        <input type="hidden" name="breweryId" th:value="${brewery != null ? brewery.id : ''}"/>
-        <label class="inline">Import Recipe XML
-          <input type="file" name="file" accept=".xml" required />
-        </label>
-        <label class="inline" style="margin-left:.5rem">
-          <input type="checkbox" name="force"/> overwrite duplicates
-        </label>
-        <button class="btn" type="submit">Import Recipe</button>
-      </form>
+  <section class="page-section" th:if="${tab == 'returned'}">
+    <div class="section-heading">
+      <div>
+        <h3>Returned inventory</h3>
+        <p class="muted">Kegs back from venues and ready for cleaning.</p>
+      </div>
     </div>
 
-    <table class="table">
-      <thead>
+    <div class="table-wrapper">
+      <table class="table">
+        <thead>
         <tr>
-          <th>Name</th>
-          <th>Style</th>
-          <th>ABV</th>
-          <th class="actions">Actions</th>
+          <th>Serial</th>
+          <th>Beer</th>
+          <th>Size</th>
+          <th>Status</th>
         </tr>
-      </thead>
-      <tbody>
-        <tr th:each="b : ${catalogBeers}">
-          <td th:text="${b.name}">Beer</td>
-          <td th:text="${b.style}">Style</td>
-          <td th:text="${#numbers.formatDecimal(b.abv, 1, 1)} + '%'">5.5%</td>
-          <td class="actions">
-            <a class="btn" th:href="@{'/admin/catalog/recipes'(q=${b.name})}">Edit Recipe</a>
+        </thead>
+        <tbody>
+        <tr th:each="k : ${returnedKegs}">
+          <td th:text="${k.serialNumber}">SER-040</td>
+          <td th:text="${k.beer != null ? k.beer.name : '-'}">Beer</td>
+          <td th:text="${k.size}">HALF_BARREL</td>
+          <td>
+            <span class="badge gray" th:text="${k.status}">RETURNED</span>
           </td>
         </tr>
-      </tbody>
-    </table>
+        <tr th:if="${#lists.isEmpty(returnedKegs)}">
+          <td class="muted" colspan="4">No kegs have been returned yet.</td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
   </section>
-</main>
-<div th:replace="~{fragments/footer :: footer}"></div>
-</body></html>
+
+  <section class="page-section" th:if="${tab == 'users'}">
+    <div class="section-heading">
+      <div>
+        <h3>Brewery users</h3>
+        <p class="muted">Filter by venue to review scoped access.</p>
+      </div>
+    </div>
+
+    <form method="get" action="/admin/brewery" class="form-inline">
+      <input type="hidden" name="tab" value="users" />
+      <div class="form-group">
+        <label for="userVenue">Filter by venue</label>
+        <select id="userVenue" name="userVenueId">
+          <option value="">All venues</option>
+          <option th:each="v : ${venues}" th:value="${v.id}" th:text="${v.name}"
+                  th:selected="${userVenueId} == ${v.id}">Venue</option>
+        </select>
+      </div>
+      <div class="form-actions">
+        <button class="btn secondary" type="submit">Apply</button>
+      </div>
+    </form>
+
+    <div class="table-wrapper">
+      <table class="table">
+        <thead>
+        <tr>
+          <th>Username</th>
+          <th>Role</th>
+          <th>Brewery</th>
+          <th>Taproom</th>
+          <th>Bar</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="u : ${breweryUsers}">
+          <td th:text="${u.username}">user</td>
+          <td th:text="${#strings.replace(u.role,'ROLE_','')}">role</td>
+          <td th:text="${u.brewery != null ? u.brewery.name : '-'}">-</td>
+          <td th:text="${u.taproom != null ? u.taproom.name : '-'}">-</td>
+          <td th:text="${u.bar != null ? u.bar.name : '-'}">-</td>
+        </tr>
+        <tr th:if="${#lists.isEmpty(breweryUsers)}">
+          <td class="muted" colspan="5">No users found for the selected filter.</td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="page-section" th:if="${tab == 'catalog'}">
+    <div class="section-heading">
+      <div>
+        <h3>Brewery catalog</h3>
+        <p class="muted">Beers attached to active kegs or owned by this brewery.</p>
+      </div>
+    </div>
+
+    <div class="card-grid">
+      <article class="content-card" th:each="beer : ${catalogBeers}">
+        <header>
+          <div>
+            <h3 th:text="${beer.name}">Beer Name</h3>
+            <p class="muted" th:text="${beer.style}">Style</p>
+          </div>
+        </header>
+        <footer class="muted">
+          ABV <span th:text="${beer.abv}">0</span>%
+        </footer>
+      </article>
+      <article class="content-card" th:if="${#lists.isEmpty(catalogBeers)}">
+        <header>
+          <div>
+            <h3>Catalog empty</h3>
+            <p class="muted">Link beers to kegs or assign BJCP styles to populate this view.</p>
+          </div>
+        </header>
+      </article>
+    </div>
+  </section>
+</section>
+</html>

--- a/src/main/resources/templates/admin/catalog-recipe-edit.html
+++ b/src/main/resources/templates/admin/catalog-recipe-edit.html
@@ -1,212 +1,322 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-<head>
-  <meta charset="UTF-8"/>
-  <title th:text="${'Edit Recipe — ' + (recipe != null ? recipe.name : '')}">Edit Recipe</title>
-  <link rel="stylesheet" th:href="@{/css/app.css}"/>
-  <style>
-    .form-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:.75rem}
-    .actions-row{display:flex;gap:.5rem;flex-wrap:wrap;align-items:center;margin:.75rem 0}
-  </style>
-</head>
-<body>
-<header>
-  <h1>Edit Recipe</h1>
-  <p><a class="btn ghost" th:href="@{/admin/catalog/recipes}">⟵ Back to Recipes</a></p>
-</header>
-<main>
-  <form method="post" th:action="@{'/admin/catalog/recipes/' + ${recipe.id}}">
-    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-    <div class="form-grid">
-      <label>Name
-        <input name="name" th:value="${recipe.name}" required />
-      </label>
-      <label>Style Name
-        <input name="styleName" th:value="${recipe.styleName}" />
-      </label>
-      <label>Type
-        <input name="type" th:value="${recipe.type}" />
-      </label>
-      <label>Batch Size (L)
-        <input type="number" step="0.1" name="batchSizeLiters" th:value="${recipe.batchSizeLiters}" />
-      </label>
-      <label>Boil Time (min)
-        <input type="number" step="1" name="boilTimeMinutes" th:value="${recipe.boilTimeMinutes}" />
-      </label>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="layouts/app :: layout(${recipe != null ? 'Recipe · ' + recipe.name : 'Recipe Editor'}, 'recipes', 'Brew house details and ingredient inventory.', ~{::section[@id='page-content']})">
+<section id="page-content">
+  <section class="page-section">
+    <div class="section-heading">
+      <div>
+        <h2 th:text="${recipe != null ? recipe.name : 'Recipe'}">Recipe</h2>
+        <p class="muted">Update core metadata and share exports with production teams.</p>
+      </div>
+      <div class="actions">
+        <a class="btn ghost" th:href="@{/admin/catalog/recipes}">Back to recipes</a>
+        <a class="btn ghost" th:href="@{'/admin/catalog/recipes/' + ${recipe.id} + '/export'(format='beerxml')}">Export BeerXML</a>
+        <a class="btn ghost" th:href="@{'/admin/catalog/recipes/' + ${recipe.id} + '/export'(format='beersmith')}">Export BeerSmith</a>
+      </div>
     </div>
-    <label>Notes
-      <textarea name="notes" rows="6" th:text="${recipe.notes}"></textarea>
-    </label>
-    <div class="actions-row">
-      <button class="btn" type="submit">Save</button>
-      <a class="btn" th:href="@{'/admin/catalog/recipes/' + ${recipe.id} + '/export'(format='beerxml')}">Export BeerXML</a>
-      <a class="btn" th:href="@{'/admin/catalog/recipes/' + ${recipe.id} + '/export'(format='beersmith')}">Export BeerSmith XML</a>
-    </div>
-  </form>
+  </section>
 
-  <section>
-    <h2>Fermentables</h2>
-    <table class="table">
-      <thead><tr><th>Name</th><th>Amount (kg)</th><th>Yield %</th><th>Color L</th><th>Late</th><th>Type</th><th class="actions">Actions</th></tr></thead>
-      <tbody>
-        <tr th:each="f : ${recipe.fermentables}">
-          <td th:text="${f.name}">Pale Malt</td>
-          <td th:text="${f.amountKg}">4.5</td>
-          <td th:text="${f.yieldPercent}">80</td>
-          <td th:text="${f.colorLovibond}">3</td>
-          <td th:text="${f.lateAddition}">false</td>
-          <td th:text="${f.type}">Grain</td>
-          <td class="actions">
-            <form method="post" th:action="@{'/admin/catalog/recipes/' + ${recipe.id} + '/fermentables/' + ${f.id} + '/delete'}">
-              <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-              <button class="btn danger" type="submit">Remove</button>
-            </form>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+  <section class="page-section">
+    <div class="card-grid">
+      <article class="metric-card">
+        <header>
+          <h3>Fermentables</h3>
+          <span class="metric-pill success" th:text="${fermentableCount} + ' entries'">0 entries</span>
+        </header>
+        <div class="metric-value" th:text="${fermentableCount}">0</div>
+        <footer class="muted">Grains and fermentable additions.</footer>
+      </article>
+      <article class="metric-card">
+        <header>
+          <h3>Hops</h3>
+          <span class="metric-pill info" th:text="${hopCount} + ' charges'">0 charges</span>
+        </header>
+        <div class="metric-value" th:text="${hopCount}">0</div>
+        <footer class="muted">Hop additions across the boil schedule.</footer>
+      </article>
+      <article class="metric-card">
+        <header>
+          <h3>Yeasts &amp; Misc</h3>
+          <span class="metric-pill warning" th:text="${yeastCount} + ' yeasts'">0 yeasts</span>
+        </header>
+        <div class="metric-value" th:text="${miscCount}">0</div>
+        <footer class="muted">Supporting misc additions and processing aids.</footer>
+      </article>
+      <article class="metric-card">
+        <header>
+          <h3>Mash steps</h3>
+          <span class="metric-pill success" th:text="${mashStepCount} + ' stages'">0 stages</span>
+        </header>
+        <div class="metric-value" th:text="${mashStepCount}">0</div>
+        <footer class="muted">Infusion or decoction steps defined.</footer>
+      </article>
+    </div>
+  </section>
+
+  <section class="page-section">
+    <form method="post" th:action="@{'/admin/catalog/recipes/' + ${recipe.id}}" class="form-grid">
+      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+      <div class="form-group">
+        <label for="recipeName">Name</label>
+        <input id="recipeName" name="name" th:value="${recipe.name}" required />
+      </div>
+      <div class="form-group">
+        <label for="styleName">Style name</label>
+        <input id="styleName" name="styleName" th:value="${recipe.styleName}" />
+      </div>
+      <div class="form-group">
+        <label for="recipeType">Type</label>
+        <input id="recipeType" name="type" th:value="${recipe.type}" />
+      </div>
+      <div class="form-group">
+        <label for="batchSize">Batch size (L)</label>
+        <input id="batchSize" type="number" step="0.1" name="batchSizeLiters" th:value="${recipe.batchSizeLiters}" />
+      </div>
+      <div class="form-group">
+        <label for="boilTime">Boil time (min)</label>
+        <input id="boilTime" type="number" step="1" name="boilTimeMinutes" th:value="${recipe.boilTimeMinutes}" />
+      </div>
+      <div class="form-group form-group--full">
+        <label for="recipeNotes">Notes</label>
+        <textarea id="recipeNotes" name="notes" rows="6" th:text="${recipe.notes}"></textarea>
+      </div>
+      <div class="form-actions">
+        <button class="btn primary" type="submit">Save recipe</button>
+      </div>
+    </form>
+  </section>
+
+  <section class="page-section">
+    <div class="section-heading">
+      <div>
+        <h3>Fermentables</h3>
+        <p class="muted">Tracked for grist bills and mash planning.</p>
+      </div>
+    </div>
+    <div class="table-wrapper">
+      <table class="table">
+        <thead>
+          <tr><th>Name</th><th>Amount (kg)</th><th>Yield %</th><th>Color L</th><th>Late</th><th>Type</th><th aria-label="Actions"></th></tr>
+        </thead>
+        <tbody>
+          <tr th:each="f : ${recipe.fermentables}">
+            <td th:text="${f.name}">Pale Malt</td>
+            <td th:text="${f.amountKg}">4.5</td>
+            <td th:text="${f.yieldPercent}">80</td>
+            <td th:text="${f.colorLovibond}">3</td>
+            <td th:text="${f.lateAddition}">false</td>
+            <td th:text="${f.type}">Grain</td>
+            <td class="actions">
+              <form method="post" th:action="@{'/admin/catalog/recipes/' + ${recipe.id} + '/fermentables/' + ${f.id} + '/delete'}" class="form-inline form-inline--compact">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                <div class="form-actions">
+                  <button class="btn critical outline" type="submit">Remove</button>
+                </div>
+              </form>
+            </td>
+          </tr>
+          <tr th:if="${#lists.isEmpty(recipe.fermentables)}">
+            <td class="muted" colspan="7">No fermentables recorded yet.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
     <form method="post" th:action="@{'/admin/catalog/recipes/' + ${recipe.id} + '/fermentables/add'}" class="form-grid">
-      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-      <label>Name<input name="name" required/></label>
-      <label>Amount Kg<input type="number" step="0.001" name="amountKg"/></label>
-      <label>Yield %<input type="number" step="0.1" name="yieldPercent"/></label>
-      <label>Color L<input type="number" step="0.1" name="colorLovibond"/></label>
-      <label>Late Addition <input type="checkbox" name="lateAddition"/></label>
-      <label>Type<input name="type"/></label>
-      <button class="btn" type="submit">Add Fermentable</button>
+      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+      <div class="form-group"><label>Name<input name="name" required /></label></div>
+      <div class="form-group"><label>Amount (kg)<input type="number" step="0.001" name="amountKg" /></label></div>
+      <div class="form-group"><label>Yield %<input type="number" step="0.1" name="yieldPercent" /></label></div>
+      <div class="form-group"><label>Color L<input type="number" step="0.1" name="colorLovibond" /></label></div>
+      <div class="form-group"><label>Late addition <input type="checkbox" name="lateAddition" /></label></div>
+      <div class="form-group"><label>Type<input name="type" /></label></div>
+      <div class="form-actions"><button class="btn secondary" type="submit">Add fermentable</button></div>
     </form>
   </section>
 
-  <section>
-    <h2>Hops</h2>
-    <table class="table">
-      <thead><tr><th>Name</th><th>Alpha %</th><th>Amount (g)</th><th>Time (min)</th><th>Use</th><th>Form</th><th>IBU</th><th class="actions">Actions</th></tr></thead>
-      <tbody>
-        <tr th:each="h : ${recipe.hops}">
-          <td th:text="${h.name}">Cascade</td>
-          <td th:text="${h.alphaAcid}">5.5</td>
-          <td th:text="${h.amountGrams}">28</td>
-          <td th:text="${h.timeMinutes}">60</td>
-          <td th:text="${h.useFor}">Boil</td>
-          <td th:text="${h.form}">Pellet</td>
-          <td th:text="${h.ibuContribution}">25</td>
-          <td class="actions">
-            <form method="post" th:action="@{'/admin/catalog/recipes/' + ${recipe.id} + '/hops/' + ${h.id} + '/delete'}">
-              <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-              <button class="btn danger" type="submit">Remove</button>
-            </form>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+  <section class="page-section">
+    <div class="section-heading">
+      <div>
+        <h3>Hops</h3>
+        <p class="muted">Bittering and aroma schedule with IBU tracking.</p>
+      </div>
+    </div>
+    <div class="table-wrapper">
+      <table class="table">
+        <thead>
+          <tr><th>Name</th><th>Alpha %</th><th>Amount (g)</th><th>Time (min)</th><th>Use</th><th>Form</th><th>IBU</th><th aria-label="Actions"></th></tr>
+        </thead>
+        <tbody>
+          <tr th:each="h : ${recipe.hops}">
+            <td th:text="${h.name}">Cascade</td>
+            <td th:text="${h.alphaAcid}">5.5</td>
+            <td th:text="${h.amountGrams}">28</td>
+            <td th:text="${h.timeMinutes}">60</td>
+            <td th:text="${h.useFor}">Boil</td>
+            <td th:text="${h.form}">Pellet</td>
+            <td th:text="${h.ibuContribution}">25</td>
+            <td class="actions">
+              <form method="post" th:action="@{'/admin/catalog/recipes/' + ${recipe.id} + '/hops/' + ${h.id} + '/delete'}" class="form-inline form-inline--compact">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                <div class="form-actions">
+                  <button class="btn critical outline" type="submit">Remove</button>
+                </div>
+              </form>
+            </td>
+          </tr>
+          <tr th:if="${#lists.isEmpty(recipe.hops)}">
+            <td class="muted" colspan="8">No hop additions recorded.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
     <form method="post" th:action="@{'/admin/catalog/recipes/' + ${recipe.id} + '/hops/add'}" class="form-grid">
-      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-      <label>Name<input name="name" required/></label>
-      <label>Alpha %<input type="number" step="0.01" name="alphaAcid"/></label>
-      <label>Amount (g)<input type="number" step="0.1" name="amountGrams"/></label>
-      <label>Time (min)<input type="number" step="1" name="timeMinutes"/></label>
-      <label>Use<input name="useFor"/></label>
-      <label>Form<input name="form"/></label>
-      <label>IBU<input type="number" step="0.1" name="ibuContribution"/></label>
-      <button class="btn" type="submit">Add Hop</button>
+      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+      <div class="form-group"><label>Name<input name="name" required /></label></div>
+      <div class="form-group"><label>Alpha %<input type="number" step="0.01" name="alphaAcid" /></label></div>
+      <div class="form-group"><label>Amount (g)<input type="number" step="0.1" name="amountGrams" /></label></div>
+      <div class="form-group"><label>Time (min)<input type="number" step="1" name="timeMinutes" /></label></div>
+      <div class="form-group"><label>Use<input name="useFor" /></label></div>
+      <div class="form-group"><label>Form<input name="form" /></label></div>
+      <div class="form-group"><label>IBU<input type="number" step="0.1" name="ibuContribution" /></label></div>
+      <div class="form-actions"><button class="btn secondary" type="submit">Add hop</button></div>
     </form>
   </section>
 
-  <section>
-    <h2>Yeasts</h2>
-    <table class="table">
-      <thead><tr><th>Name</th><th>Lab</th><th>Product</th><th>Type</th><th>Form</th><th>Attenuation</th><th class="actions">Actions</th></tr></thead>
-      <tbody>
-        <tr th:each="y : ${recipe.yeasts}">
-          <td th:text="${y.name}">US-05</td>
-          <td th:text="${y.laboratory}">Fermentis</td>
-          <td th:text="${y.productId}">US-05</td>
-          <td th:text="${y.type}">Ale</td>
-          <td th:text="${y.form}">Dry</td>
-          <td th:text="${y.attenuation}">78</td>
-          <td class="actions">
-            <form method="post" th:action="@{'/admin/catalog/recipes/' + ${recipe.id} + '/yeasts/' + ${y.id} + '/delete'}">
-              <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-              <button class="btn danger" type="submit">Remove</button>
-            </form>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+  <section class="page-section">
+    <div class="section-heading">
+      <div>
+        <h3>Yeasts</h3>
+        <p class="muted">Fermentation strains in use for this recipe.</p>
+      </div>
+    </div>
+    <div class="table-wrapper">
+      <table class="table">
+        <thead>
+          <tr><th>Name</th><th>Lab</th><th>Product</th><th>Type</th><th>Form</th><th>Attenuation</th><th aria-label="Actions"></th></tr>
+        </thead>
+        <tbody>
+          <tr th:each="y : ${recipe.yeasts}">
+            <td th:text="${y.name}">US-05</td>
+            <td th:text="${y.laboratory}">Fermentis</td>
+            <td th:text="${y.productId}">US-05</td>
+            <td th:text="${y.type}">Ale</td>
+            <td th:text="${y.form}">Dry</td>
+            <td th:text="${y.attenuation}">78</td>
+            <td class="actions">
+              <form method="post" th:action="@{'/admin/catalog/recipes/' + ${recipe.id} + '/yeasts/' + ${y.id} + '/delete'}" class="form-inline form-inline--compact">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                <div class="form-actions">
+                  <button class="btn critical outline" type="submit">Remove</button>
+                </div>
+              </form>
+            </td>
+          </tr>
+          <tr th:if="${#lists.isEmpty(recipe.yeasts)}">
+            <td class="muted" colspan="7">No yeasts recorded.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
     <form method="post" th:action="@{'/admin/catalog/recipes/' + ${recipe.id} + '/yeasts/add'}" class="form-grid">
-      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-      <label>Name<input name="name"/></label>
-      <label>Laboratory<input name="laboratory"/></label>
-      <label>Product ID<input name="productId"/></label>
-      <label>Type<input name="type"/></label>
-      <label>Form<input name="form"/></label>
-      <label>Attenuation<input type="number" step="0.1" name="attenuation"/></label>
-      <button class="btn" type="submit">Add Yeast</button>
+      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+      <div class="form-group"><label>Name<input name="name" /></label></div>
+      <div class="form-group"><label>Laboratory<input name="laboratory" /></label></div>
+      <div class="form-group"><label>Product ID<input name="productId" /></label></div>
+      <div class="form-group"><label>Type<input name="type" /></label></div>
+      <div class="form-group"><label>Form<input name="form" /></label></div>
+      <div class="form-group"><label>Attenuation<input type="number" step="0.1" name="attenuation" /></label></div>
+      <div class="form-actions"><button class="btn secondary" type="submit">Add yeast</button></div>
     </form>
   </section>
 
-  <section>
-    <h2>Misc</h2>
-    <table class="table">
-      <thead><tr><th>Name</th><th>Type</th><th>Amount</th><th>Unit</th><th>Use</th><th class="actions">Actions</th></tr></thead>
-      <tbody>
-        <tr th:each="m : ${recipe.miscs}">
-          <td th:text="${m.name}">Irish Moss</td>
-          <td th:text="${m.type}">Fining</td>
-          <td th:text="${m.amount}">5</td>
-          <td th:text="${m.amountUnit}">g</td>
-          <td th:text="${m.useFor}">Boil</td>
-          <td class="actions">
-            <form method="post" th:action="@{'/admin/catalog/recipes/' + ${recipe.id} + '/miscs/' + ${m.id} + '/delete'}">
-              <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-              <button class="btn danger" type="submit">Remove</button>
-            </form>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+  <section class="page-section">
+    <div class="section-heading">
+      <div>
+        <h3>Misc additions</h3>
+        <p class="muted">Fining agents, spices, or clarifying aids.</p>
+      </div>
+    </div>
+    <div class="table-wrapper">
+      <table class="table">
+        <thead>
+          <tr><th>Name</th><th>Type</th><th>Amount</th><th>Unit</th><th>Use</th><th aria-label="Actions"></th></tr>
+        </thead>
+        <tbody>
+          <tr th:each="m : ${recipe.miscs}">
+            <td th:text="${m.name}">Irish Moss</td>
+            <td th:text="${m.type}">Fining</td>
+            <td th:text="${m.amount}">5</td>
+            <td th:text="${m.amountUnit}">g</td>
+            <td th:text="${m.useFor}">Boil</td>
+            <td class="actions">
+              <form method="post" th:action="@{'/admin/catalog/recipes/' + ${recipe.id} + '/miscs/' + ${m.id} + '/delete'}" class="form-inline form-inline--compact">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                <div class="form-actions">
+                  <button class="btn critical outline" type="submit">Remove</button>
+                </div>
+              </form>
+            </td>
+          </tr>
+          <tr th:if="${#lists.isEmpty(recipe.miscs)}">
+            <td class="muted" colspan="6">No misc additions recorded.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
     <form method="post" th:action="@{'/admin/catalog/recipes/' + ${recipe.id} + '/miscs/add'}" class="form-grid">
-      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-      <label>Name<input name="name"/></label>
-      <label>Type<input name="type"/></label>
-      <label>Amount<input type="number" step="0.1" name="amount"/></label>
-      <label>Unit<input name="amountUnit"/></label>
-      <label>Use<input name="useFor"/></label>
-      <button class="btn" type="submit">Add Misc</button>
+      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+      <div class="form-group"><label>Name<input name="name" /></label></div>
+      <div class="form-group"><label>Type<input name="type" /></label></div>
+      <div class="form-group"><label>Amount<input type="number" step="0.1" name="amount" /></label></div>
+      <div class="form-group"><label>Unit<input name="amountUnit" /></label></div>
+      <div class="form-group"><label>Use<input name="useFor" /></label></div>
+      <div class="form-actions"><button class="btn secondary" type="submit">Add misc</button></div>
     </form>
   </section>
 
-  <section>
-    <h2>Mash Steps</h2>
-    <table class="table">
-      <thead><tr><th>Name</th><th>Type</th><th>Temp (°C)</th><th>Time (min)</th><th>Infuse (L)</th><th class="actions">Actions</th></tr></thead>
-      <tbody>
-        <tr th:each="ms : ${recipe.mashSteps}">
-          <td th:text="${ms.name}">Sacch Rest</td>
-          <td th:text="${ms.type}">Infusion</td>
-          <td th:text="${ms.stepTempC}">66.0</td>
-          <td th:text="${ms.stepTimeMinutes}">60</td>
-          <td th:text="${ms.infuseAmountLiters}">10.0</td>
-          <td class="actions">
-            <form method="post" th:action="@{'/admin/catalog/recipes/' + ${recipe.id} + '/mash/' + ${ms.id} + '/delete'}">
-              <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-              <button class="btn danger" type="submit">Remove</button>
-            </form>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+  <section class="page-section">
+    <div class="section-heading">
+      <div>
+        <h3>Mash schedule</h3>
+        <p class="muted">Infusion and decoction steps to guide the mash tun.</p>
+      </div>
+    </div>
+    <div class="table-wrapper">
+      <table class="table">
+        <thead>
+          <tr><th>Name</th><th>Type</th><th>Temp (°C)</th><th>Time (min)</th><th>Infuse (L)</th><th aria-label="Actions"></th></tr>
+        </thead>
+        <tbody>
+          <tr th:each="ms : ${recipe.mashSteps}">
+            <td th:text="${ms.name}">Sacch Rest</td>
+            <td th:text="${ms.type}">Infusion</td>
+            <td th:text="${ms.stepTempC}">66.0</td>
+            <td th:text="${ms.stepTimeMinutes}">60</td>
+            <td th:text="${ms.infuseAmountLiters}">10.0</td>
+            <td class="actions">
+              <form method="post" th:action="@{'/admin/catalog/recipes/' + ${recipe.id} + '/mash/' + ${ms.id} + '/delete'}" class="form-inline form-inline--compact">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                <div class="form-actions">
+                  <button class="btn critical outline" type="submit">Remove</button>
+                </div>
+              </form>
+            </td>
+          </tr>
+          <tr th:if="${#lists.isEmpty(recipe.mashSteps)}">
+            <td class="muted" colspan="6">No mash steps captured.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
     <form method="post" th:action="@{'/admin/catalog/recipes/' + ${recipe.id} + '/mash/add'}" class="form-grid">
-      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-      <label>Name<input name="name"/></label>
-      <label>Type<input name="type"/></label>
-      <label>Temp (°C)<input type="number" step="0.1" name="stepTempC"/></label>
-      <label>Time (min)<input type="number" step="1" name="stepTimeMinutes"/></label>
-      <label>Infuse (L)<input type="number" step="0.1" name="infuseAmountLiters"/></label>
-      <button class="btn" type="submit">Add Step</button>
+      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+      <div class="form-group"><label>Name<input name="name" /></label></div>
+      <div class="form-group"><label>Type<input name="type" /></label></div>
+      <div class="form-group"><label>Temp (°C)<input type="number" step="0.1" name="stepTempC" /></label></div>
+      <div class="form-group"><label>Time (min)<input type="number" step="1" name="stepTimeMinutes" /></label></div>
+      <div class="form-group"><label>Infuse (L)<input type="number" step="0.1" name="infuseAmountLiters" /></label></div>
+      <div class="form-actions"><button class="btn secondary" type="submit">Add step</button></div>
     </form>
   </section>
-</main>
-<div th:replace="~{fragments/footer :: footer}"></div>
-</body>
+</section>
 </html>

--- a/src/main/resources/templates/admin/catalog-recipes.html
+++ b/src/main/resources/templates/admin/catalog-recipes.html
@@ -1,39 +1,72 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-<head>
-  <meta charset="UTF-8"/>
-  <title>Catalog — Recipes</title>
-  <link rel="stylesheet" th:href="@{/css/app.css}"/>
-  <style>.row-actions{white-space:nowrap}</style>
-  </head>
-<body>
-<header>
-  <h1>Catalog — Recipes</h1>
-  <p><a class="btn ghost" th:href="@{/admin/brewery(tab='catalog')}">⟵ Back to Brewery</a></p>
-  <form method="get" th:action="@{/admin/catalog/recipes}" class="inline" style="margin:.5rem 0;">
-    <input name="q" placeholder="Search by name or style…" th:value="${q}"/>
-    <button class="btn" type="submit">Search</button>
-  </form>
-</header>
-<main>
-  <table class="table">
-    <thead>
-      <tr><th>Name</th><th>Style</th><th>Type</th><th>Batch (L)</th><th>Boil (min)</th><th class="actions">Actions</th></tr>
-    </thead>
-    <tbody>
-      <tr th:each="r : ${recipes}">
-        <td th:text="${r.name}">Name</td>
-        <td th:text="${r.styleName}">Style</td>
-        <td th:text="${r.type}">Type</td>
-        <td th:text="${r.batchSizeLiters}">20</td>
-        <td th:text="${r.boilTimeMinutes}">60</td>
-        <td class="actions row-actions">
-          <a class="btn" th:href="@{'/admin/catalog/recipes/' + ${r.id}}">Edit</a>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</main>
-<div th:replace="~{fragments/footer :: footer}"></div>
-</body>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="layouts/app :: layout('Recipe Catalog', 'recipes', 'Brewery recipes and production metadata.', ~{::section[@id='page-content']})">
+<section id="page-content">
+  <section class="page-section">
+    <div class="card-grid">
+      <article class="metric-card">
+        <header>
+          <h3>Total recipes</h3>
+          <span class="metric-pill success" th:text="${recipeCount} + ' on file'">0 on file</span>
+        </header>
+        <div class="metric-value" th:text="${recipeCount}">0</div>
+        <footer class="muted">Visible to your brewery team.</footer>
+      </article>
+    </div>
+  </section>
+
+  <section class="page-section">
+    <div class="section-heading">
+      <div>
+        <h2>Recipe library</h2>
+        <p class="muted">Search across brewery recipes and jump into detailed edits.</p>
+      </div>
+      <div class="actions">
+        <a class="btn ghost" th:href="@{/admin/brewery(tab='catalog')}">Back to brewery</a>
+      </div>
+    </div>
+
+    <form method="get" th:action="@{/admin/catalog/recipes}" class="form-inline">
+      <div class="form-group">
+        <label for="recipeSearch">Search</label>
+        <input id="recipeSearch" name="q" placeholder="Name or style…" th:value="${q}" />
+      </div>
+      <div class="form-actions">
+        <button class="btn primary" type="submit">Run search</button>
+      </div>
+    </form>
+
+    <div class="table-wrapper">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Style</th>
+            <th>Type</th>
+            <th>Batch (L)</th>
+            <th>Boil (min)</th>
+            <th aria-label="Actions"></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr th:each="r : ${recipes}">
+            <td th:text="${r.name}">Name</td>
+            <td th:text="${r.styleName}">Style</td>
+            <td>
+              <span class="badge blue" th:text="${r.type != null ? r.type : '—'}">Type</span>
+            </td>
+            <td th:text="${r.batchSizeLiters}">20</td>
+            <td th:text="${r.boilTimeMinutes}">60</td>
+            <td class="actions">
+              <a class="btn secondary" th:href="@{'/admin/catalog/recipes/' + ${r.id}}">Open</a>
+            </td>
+          </tr>
+          <tr th:if="${#lists.isEmpty(recipes)}">
+            <td class="muted" colspan="6">No recipes match your search.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</section>
 </html>

--- a/src/main/resources/templates/admin/events.html
+++ b/src/main/resources/templates/admin/events.html
@@ -1,46 +1,60 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-<head>
-    <meta charset="UTF-8">
-    <title th:text="'Keg Event Log — ' + ${venue.name}">Keg Event Log</title>
-    <link rel="stylesheet" th:href="@{/css/app.css}"/>
-</head>
-<body>
-<div class="container">
-    <header>
-        <h1 th:text="'Keg Event Log — ' + ${venue.name}">Keg Event Log</h1>
-        <div class="toolbar">
-            <a class="btn" th:href="@{'/admin/venue/' + ${venue.id}}">⟵ Back to Venue Admin</a>
-            <a class="btn ghost" th:href="@{'/taplist?venueId=' + ${venue.id}}">View Taplist</a>
-        </div>
-    </header>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="layouts/app :: layout(${'Keg Events · ' + (venue != null ? venue.name : 'Venue')}, 'taproom', 'Audit trail for pours, blows, and maintenance at this venue.', ~{::section[@id='page-content']})">
+<section id="page-content">
+  <section class="page-section">
+    <div class="card-grid">
+      <article class="metric-card">
+        <header>
+          <h3>Total events</h3>
+          <span class="metric-pill success" th:text="${events != null ? events.size() : 0} + ' recorded'">0 recorded</span>
+        </header>
+        <div class="metric-value" th:text="${events != null ? events.size() : 0}">0</div>
+        <footer class="muted">Taproom activity captured for this venue.</footer>
+      </article>
+    </div>
+  </section>
 
-    <div class="alert muted" th:if="${#lists.isEmpty(events)}">No events yet.</div>
+  <section class="page-section">
+    <div class="section-heading">
+      <div>
+        <h2 th:text="${venue != null ? venue.name : 'Venue events'}">Venue events</h2>
+        <p class="muted">Use the event log to understand pours, low alerts, and keg swaps.</p>
+      </div>
+      <div class="actions">
+        <a class="btn ghost" th:href="@{'/admin/venue/' + ${venue.id}}">Back to venue</a>
+        <a class="btn ghost" th:href="@{'/taplist?venueId=' + ${venue.id}}">View taplist</a>
+      </div>
+    </div>
 
-    <table class="table" th:if="${!#lists.isEmpty(events)}">
+    <div class="alert" th:if="${#lists.isEmpty(events)}">No events have been recorded yet.</div>
+
+    <div class="table-wrapper" th:if="${!#lists.isEmpty(events)}">
+      <table class="table">
         <thead>
         <tr>
-            <th>Time</th>
-            <th>Tap</th>
-            <th>Event</th>
-            <th>Ounces</th>
-            <th>Beer</th>
-            <th>Keg</th>
-            <th>By</th>
+          <th>Time</th>
+          <th>Tap</th>
+          <th>Event</th>
+          <th>Ounces</th>
+          <th>Beer</th>
+          <th>Keg</th>
+          <th>Actor</th>
         </tr>
         </thead>
         <tbody>
         <tr th:each="e : ${events}">
-            <td th:text="${e.atTime}">2025-01-01T00:00:00Z</td>
-            <td th:text="${e.placement.tap.number}">1</td>
-            <td th:text="${e.type}">POUR</td>
-            <td th:text="${e.ounces} ?: '-'">16</td>
-            <td th:text="${e.placement.keg.beer.name}">IPA</td>
-            <td th:text="${e.placement.keg.id}">42</td>
-            <td th:text="${e.actor != null ? e.actor.username : '—'}">—</td>
+          <td th:text="${e.atTime}">2025-01-01T00:00:00Z</td>
+          <td th:text="${e.placement.tap.number}">1</td>
+          <td><span class="badge blue" th:text="${e.type}">POUR</span></td>
+          <td th:text="${e.ounces} ?: '-'">16</td>
+          <td th:text="${e.placement.keg.beer.name}">IPA</td>
+          <td th:text="${e.placement.keg.id}">42</td>
+          <td th:text="${e.actor != null ? e.actor.username : '—'}">—</td>
         </tr>
         </tbody>
-    </table>
-</div>
-</body>
+      </table>
+    </div>
+  </section>
+</section>
 </html>

--- a/src/main/resources/templates/admin/site.html
+++ b/src/main/resources/templates/admin/site.html
@@ -1,27 +1,109 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-  <head>
-    <meta charset="UTF-8"/>
-    <title>Site Admin</title>
-    <link rel="stylesheet" th:href="@{/css/app.css}"/>
-  </head>
-  <body>
-    <header>
-      <h1>Site Admin</h1>
-    </header>
-    <main>
-      <p>
-        <a class="btn" th:href="@{/admin/users}">Manage Users</a>
-      </p>
-      <h2>Breweries</h2>
-      <ul>
-        <li th:each="b : ${breweries}" th:text="${b.name}">Brewery</li>
-      </ul>
-      <h2>Bars</h2>
-      <ul>
-        <li th:each="b : ${bars}" th:text="${b.name}">Bar</li>
-      </ul>
-    </main>
-    <div th:replace="~{fragments/footer :: footer}"></div>
-  </body>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="layouts/app :: layout('Control Center', 'site', 'Cross-brewery visibility and admin shortcuts for the Mythic Tales network.', ~{::section[@id='page-content']})">
+<section id="page-content">
+  <section class="page-section">
+    <div class="card-grid">
+      <article class="metric-card">
+        <header>
+          <h3>Brewery footprint</h3>
+          <span class="metric-pill success" th:text="${breweryCount} + ' total'">0 total</span>
+        </header>
+        <div class="metric-value" th:text="${breweryCount}">0</div>
+        <footer class="muted">Active breweries with <span th:text="${taproomCount}">0</span> taprooms.</footer>
+      </article>
+      <article class="metric-card">
+        <header>
+          <h3>Retail partners</h3>
+          <span class="metric-pill warning" th:text="${barCount} + ' total'">0 total</span>
+        </header>
+        <div class="metric-value" th:text="${barCount}">0</div>
+        <footer class="muted">Bars and venues connected to brewing operations.</footer>
+      </article>
+      <article class="metric-card">
+        <header>
+          <h3>Distributed kegs</h3>
+          <span class="metric-pill info" th:text="${tappedKegCount} + ' tapped'">0 tapped</span>
+        </header>
+        <div class="metric-value" th:text="${distributedKegCount}">0</div>
+        <footer class="muted">Inventory currently pouring at partner venues.</footer>
+      </article>
+    </div>
+  </section>
+
+  <section class="page-section">
+    <article class="content-card">
+      <header>
+        <div>
+          <h3>Quick actions</h3>
+          <p class="muted">Provision users, sync recipes, or onboard a new venue.</p>
+        </div>
+      </header>
+      <div class="actions">
+        <a class="btn primary" th:href="@{/admin/users}">Manage user access</a>
+        <a class="btn secondary" th:href="@{/admin/catalog/recipes}">Review recipes</a>
+        <a class="btn ghost" th:href="@{/admin/brewery}">Add brewery</a>
+        <a class="btn ghost" th:href="@{/admin/bar}">Invite bar partner</a>
+      </div>
+    </article>
+  </section>
+
+  <section class="page-section">
+    <div class="section-heading">
+      <div>
+        <h2>Breweries</h2>
+        <p class="muted">List of breweries configured in the platform.</p>
+      </div>
+    </div>
+    <div class="table-wrapper">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>City</th>
+          <th>State</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr th:each="b : ${breweries}">
+          <td th:text="${b.name}">Brewery Name</td>
+          <td th:text="${b.address != null ? b.address.city : '-'}">City</td>
+          <td th:text="${b.address != null ? b.address.state : '-'}">State</td>
+        </tr>
+        <tr th:if="${#lists.isEmpty(breweries)}">
+          <td colspan="3" class="muted">No breweries configured yet.</td>
+        </tr>
+      </tbody>
+    </table>
+    </div>
+  </section>
+
+  <section class="page-section">
+    <div class="section-heading">
+      <div>
+        <h2>Bars &amp; venues</h2>
+        <p class="muted">Connected retail locations by name.</p>
+      </div>
+    </div>
+    <div class="table-wrapper">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Location</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr th:each="b : ${bars}">
+          <td th:text="${b.name}">Bar Name</td>
+          <td th:text="${b.city != null ? b.city : '-'}">Location</td>
+        </tr>
+        <tr th:if="${#lists.isEmpty(bars)}">
+          <td colspan="2" class="muted">No bar partners on file.</td>
+        </tr>
+      </tbody>
+    </table>
+    </div>
+  </section>
+</section>
 </html>

--- a/src/main/resources/templates/admin/taproom.html
+++ b/src/main/resources/templates/admin/taproom.html
@@ -1,244 +1,314 @@
-
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-<head><meta charset="UTF-8"/><title>Taproom Admin</title><link rel="stylesheet" th:href="@{/css/app.css}"/></head>
-<body>
-<header>
-  <h1>Taproom Admin</h1>
-  <div class="badge" style="display:inline-block;margin-left:0.5rem;padding:0.15rem 0.4rem;border-radius:6px;background:#eef3ff;color:#2a4b8d;font-size:0.85rem;vertical-align:middle;">
-    <span th:if="${lastEvent != null}">
-      Last event: <strong th:text="${lastEvent.type}">TAP</strong>
-      <span th:text="'@ ' + ${lastEvent.atTime}">@ time</span>
-    </span>
-    <span th:if="${lastEvent == null}">No events yet</span>
-  </div>
-</header>
-<main>
-  <!-- Info section -->
-  <section>
-    <h2 th:text="${taproom != null ? 'Taproom: ' + taproom.name : 'Taproom'}">Taproom</h2>
-    <form method="post" th:action="@{/admin/taproom/updateInfo}" class="inline">
-      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-      <input type="hidden" name="taproomId" th:value="${taproom != null ? taproom.id : 0}"/>
-      <label>Name <input type="text" name="name" th:value="${taproom != null ? taproom.name : ''}"/></label>
-      <button class="btn" type="submit">Save</button>
-    </form>
-    <a class="btn ghost" th:if="${backToBrewery}" th:href="@{/admin/brewery}" style="margin-left:.5rem">⟵ Back to Brewery Admin</a>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="layouts/app :: layout($ {'Taproom Operations · ' + (taproom != null ? taproom.name : 'Taproom')}, 'taproom', 'Operate taps, manage keg inventory, and track events for this taproom.', ~{::section[@id='page-content']})">
+<section id="page-content">
+  <section class="page-section">
+    <div class="card-grid">
+      <article class="metric-card">
+        <header>
+          <h3>Tap handles</h3>
+          <span class="metric-pill success" th:text="${tapCount} + ' total'">0 total</span>
+        </header>
+        <div class="metric-value" th:text="${tapCount}">0</div>
+        <footer class="muted">Handles assigned to this taproom.</footer>
+      </article>
+      <article class="metric-card">
+        <header>
+          <h3>Active pours</h3>
+          <span class="metric-pill warning" th:text="${activeTapHandles} + ' active'">0 active</span>
+        </header>
+        <div class="metric-value" th:text="${activeTapHandles}">0</div>
+        <footer class="muted">Taps currently serving beer.</footer>
+      </article>
+      <article class="metric-card">
+        <header>
+          <h3>Available kegs</h3>
+          <span class="metric-pill info" th:text="${availableKegCount} + ' on site'">0 on site</span>
+        </header>
+        <div class="metric-value" th:text="${availableKegCount}">0</div>
+        <footer class="muted">Received kegs ready to tap.</footer>
+      </article>
+      <article class="metric-card">
+        <header>
+          <h3>Inbound / Blown</h3>
+          <span class="metric-pill success" th:text="${inboundKegCount} + ' inbound'">0 inbound</span>
+        </header>
+        <div class="metric-value" th:text="${blownKegCount}">0</div>
+        <footer class="muted">Blown kegs waiting for return.</footer>
+      </article>
+      <article class="metric-card">
+        <header>
+          <h3>Recent events</h3>
+          <span class="metric-pill success" th:text="${eventsCount} + ' logged'">0 logged</span>
+        </header>
+        <div class="metric-value" th:text="${eventsCount}">0</div>
+        <footer class="muted" th:if="${lastEvent != null}" th:text="${'Last: ' + lastEvent.type + ' @ ' + lastEvent.atTime}">Latest activity</footer>
+        <footer class="muted" th:if="${lastEvent == null}">No events recorded yet.</footer>
+      </article>
+    </div>
   </section>
-  <p><a href="/taplist">Go to Taplist</a></p>
 
-  <!-- Tabs -->
-  <div class="tabs">
-    <a th:classappend="${(tab == null or tab == 'taplist') ? ' active' : ''}"
-       th:href="@{/admin/taproom(tab='taplist')}">Taplist</a>
-    <a th:classappend="${(tab == 'kegs') ? ' active' : ''}"
-       th:href="@{/admin/taproom(tab='kegs')}">Kegs</a>
-    <a th:classappend="${(tab == 'inbound') ? ' active' : ''}"
-       th:href="@{/admin/taproom(tab='inbound')}">Inbound Kegs</a>
-    <a th:classappend="${(tab == 'blown') ? ' active' : ''}"
-       th:href="@{/admin/taproom(tab='blown')}">Blown Kegs</a>
-    <a th:classappend="${(tab == 'events') ? ' active' : ''}"
-       th:href="@{/admin/taproom(tab='events')}">Events</a>
-    <a th:classappend="${(tab == 'users') ? ' active' : ''}"
-       th:href="@{/admin/taproom(tab='users')}">Users</a>
-  </div>
+  <section class="page-section">
+    <div class="section-heading">
+      <div>
+        <h2 th:text="${taproom != null ? taproom.name : 'Taproom'}">Taproom</h2>
+        <p class="muted">Manage tap assignments, keg logistics, and team members.</p>
+      </div>
+      <div class="actions">
+        <a class="btn ghost" th:if="${backToBrewery}" th:href="@{/admin/brewery}">Back to brewery</a>
+        <a class="btn ghost" th:if="${venue != null}" th:href="@{'/admin/venue/' + ${venue.id}}">Venue Console</a>
+        <a class="btn ghost" th:if="${venue != null}" th:href="@{'/taplist?venueId=' + ${venue.id}}">Public taplist</a>
+      </div>
+    </div>
 
-  <!-- Taplist (same table as taplist page) -->
-  <section th:if="${tab == null or tab == 'taplist'}" id="taplistSection">
-    <h2>Your Taplist</h2>
-    <table class="table">
-      <thead>
-        <tr><th>Tap #</th><th>Beer</th><th>Status</th><th>Actions</th></tr>
-      </thead>
-      <tbody>
-        <tr th:each="t : ${taps}"
-            th:attr="id=${'tap-row-' + t.id}">
+    <form method="post" th:action="@{/admin/taproom/updateInfo}" class="form-inline">
+      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+      <input type="hidden" name="taproomId" th:value="${taproom != null ? taproom.id : 0}" />
+      <div class="form-group">
+        <label for="taproomName">Name</label>
+        <input id="taproomName" type="text" name="name" th:value="${taproom != null ? taproom.name : ''}" required />
+      </div>
+      <div class="form-actions">
+        <button class="btn primary" type="submit">Save</button>
+      </div>
+    </form>
+
+    <div class="tabs">
+      <a th:href="@{/admin/taproom(tab='taplist', taproomId=${taproom != null ? taproom.id : null})}"
+         th:classappend="${tab == null or tab == 'taplist'} ? ' active' : ''">Taplist</a>
+      <a th:href="@{/admin/taproom(tab='kegs', taproomId=${taproom != null ? taproom.id : null})}"
+         th:classappend="${tab == 'kegs'} ? ' active' : ''">Kegs</a>
+      <a th:href="@{/admin/taproom(tab='inbound', taproomId=${taproom != null ? taproom.id : null})}"
+         th:classappend="${tab == 'inbound'} ? ' active' : ''">Inbound</a>
+      <a th:href="@{/admin/taproom(tab='blown', taproomId=${taproom != null ? taproom.id : null})}"
+         th:classappend="${tab == 'blown'} ? ' active' : ''">Blown</a>
+      <a th:href="@{/admin/taproom(tab='events', taproomId=${taproom != null ? taproom.id : null})}"
+         th:classappend="${tab == 'events'} ? ' active' : ''">Events</a>
+      <a th:href="@{/admin/taproom(tab='users', taproomId=${taproom != null ? taproom.id : null})}"
+         th:classappend="${tab == 'users'} ? ' active' : ''">Users</a>
+    </div>
+  </section>
+
+  <section class="page-section" id="taplistSection" th:if="${tab == null or tab == 'taplist'}">
+    <div class="section-heading">
+      <div>
+        <h3>Taplist</h3>
+        <p class="muted">Pour, blow, or retap directly from the bar.</p>
+      </div>
+    </div>
+    <div class="table-wrapper">
+      <table class="table">
+        <thead>
+        <tr><th>Tap</th><th>Beer</th><th>Status</th><th>Actions</th></tr>
+        </thead>
+        <tbody>
+        <tr th:each="t : ${taps}" th:attr="id=${'tap-row-' + t.id}">
           <td th:text="${t.number}">1</td>
           <td>
             <span th:if="${t.keg != null}">
               <strong th:text="${t.keg.beer.name}">Beer</strong>
-              <span class="muted"> (</span><span class="muted" th:text="${t.keg.beer.style}">Style</span>
-              <span class="muted">, </span><span class="muted" th:text="${t.keg.beer.abv}">5.0</span><span class="muted">% ABV)</span>
+              <span class="muted" th:text="${' · ' + t.keg.beer.style + ' · ' + t.keg.beer.abv + '% ABV'}"></span>
             </span>
-            <span th:if="${t.keg == null}"><em class="muted">Empty</em></span>
+            <span th:if="${t.keg == null}" class="muted">Empty</span>
           </td>
           <td>
-            <div th:if="${t.keg != null}">
-              <div class="pintwrap" style="margin-top:.4rem;">
-                <div th:with="p=${t.keg.fillPercent}, top=10, bottom=80, gh=${bottom - top}, bh=${T(java.lang.Math).round(gh * p / 100.0)}, by=${bottom - bh}, clipId=${'clip' + t.id}, showFoam=${p >= 95}"
-                     th:classappend="${p <= 10} ? ' low' : null">
-                  <svg class="pint" width="60" height="90" viewBox="0 0 60 90" aria-label="Fill level">
-                    <defs>
-                      <clipPath th:attr="id=${clipId}">
-                        <path d="M 18 10 L 42 10 L 38 80 L 22 80 Z"></path>
-                      </clipPath>
-                      <linearGradient id="beerGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-                        <stop offset="0%" stop-color="#ffe08a"/>
-                        <stop offset="100%" stop-color="#c6862b"/>
-                      </linearGradient>
-                    </defs>
-                    <rect x="16" width="28" th:attr="y=${by},height=${bh},clip-path=|url(#${clipId})|" fill="url(#beerGrad)"></rect>
-                    <rect x="16" width="28" th:if="${showFoam}" th:attr="y=${top},height=6,clip-path=|url(#${clipId})|" fill="#ffffff" opacity="0.9"></rect>
-                    <path class="pintglass" d="M 18 10 L 42 10 L 38 80 L 22 80 Z" fill="none" stroke="#8aa3bf" stroke-width="2" th:classappend="${p <= 10} ? ' low' : null"></path>
-                  </svg>
-                  <div class="debug-tooltip">
-                    <span th:text="|${p}% — ${t.keg.remainingOunces} oz (${t.keg.size})|">%</span>
-                  </div>
-                </div>
-              </div>
+            <div th:if="${t.keg != null}" class="fillbar">
+              <div class="fill" th:style="${'width:' + t.keg.fillPercent + '%'}"></div>
             </div>
+            <span class="muted" th:text="${t.keg != null ? t.keg.fillPercent + '%' : '-'}">%</span>
           </td>
           <td>
             <div th:if="${t.keg != null}" class="actions">
-              <form method="post" th:action="@{'/taps/' + ${t.id} + '/pour'}" class="inline ajax-form"
+              <form method="post"
+                    th:action="@{'/taps/' + ${t.id} + '/pour'}"
+                    class="form-inline form-inline--compact ajax-form"
                     th:attr="data-tap-id=${t.id}">
-                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-                <input type="hidden" name="redirect" th:value="@{|/admin/taproom?taproomId=${taproom != null ? taproom.id : 0}&from=brewery&tab=taplist|}"/>
-                <input type="hidden" name="tapId" th:value="${t.id}"/>
-                <label class="inline">Pour
-                  <select name="ounces">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                <input type="hidden" name="redirect" th:value="@{|/admin/taproom?taproomId=${taproom != null ? taproom.id : 0}&from=brewery&tab=taplist|}" />
+                <input type="hidden" name="tapId" th:value="${t.id}" />
+                <div class="form-group">
+                  <label class="sr-only" th:for="${'pour-' + t.id}">Pour ounces</label>
+                  <select th:id="${'pour-' + t.id}" name="ounces">
                     <option value="4">4 oz</option>
                     <option value="8">8 oz</option>
                     <option value="12">12 oz</option>
                     <option value="16" selected>16 oz</option>
                     <option value="20">20 oz</option>
                   </select>
-                </label>
-                <button class="btn" type="submit">Pour</button>
-                <button class="btn danger" type="submit" th:formaction="@{'/taps/' + ${t.id} + '/blow'}">Blow</button>
+                </div>
+                <div class="form-actions">
+                  <button class="btn secondary" type="submit">Pour</button>
+                  <button class="btn critical outline" type="submit" th:formaction="@{'/taps/' + ${t.id} + '/blow'}">Blow</button>
+                </div>
               </form>
             </div>
             <div th:if="${t.keg == null}" class="actions">
-              <form method="post" th:action="@{'/taps/' + ${t.id} + '/tapKeg'}" class="inline ajax-form"
+              <form method="post"
+                    th:action="@{'/taps/' + ${t.id} + '/tapKeg'}"
+                    class="form-inline form-inline--compact ajax-form"
                     th:attr="data-tap-id=${t.id}">
-                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-                <input type="hidden" name="redirect" th:value="@{|/admin/taproom?taproomId=${taproom != null ? taproom.id : 0}&from=brewery&tab=taplist|}"/>
-                <input type="hidden" name="tapId" th:value="${t.id}"/>
-                <label class="inline">Keg
-                  <select name="kegId" required>
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                <input type="hidden" name="redirect" th:value="@{|/admin/taproom?taproomId=${taproom != null ? taproom.id : 0}&from=brewery&tab=taplist|}" />
+                <input type="hidden" name="tapId" th:value="${t.id}" />
+                <div class="form-group">
+                  <label class="sr-only" th:for="${'keg-' + t.id}">Select keg</label>
+                  <select th:id="${'keg-' + t.id}" name="kegId" required>
                     <option value="" disabled selected>Select untapped keg…</option>
                     <option th:each="k : ${availableKegs}" th:value="${k.id}"
-                            th:text="${k.beer.name} + ' — ' + ${k.size} + ' — ' + ${k.fillPercent} + '%'">Keg</option>
+                            th:text="${k.beer.name + ' — ' + k.size + ' — ' + k.fillPercent + '%'}">Keg</option>
                   </select>
-                </label>
-                <button class="btn" type="submit">Tap Keg</button>
+                </div>
+                <div class="form-actions">
+                  <button class="btn primary" type="submit">Tap keg</button>
+                </div>
               </form>
             </div>
           </td>
         </tr>
-      </tbody>
-    </table>
-  </section>
-
-  <!-- Kegs -->
-  <section th:if="${tab == 'kegs'}">
-    <h2>Available Kegs (Received)</h2>
-    <div class="filters">
-      <span>Status:</span>
-      <a th:href="@{/admin/taproom(tab='kegs')}" th:classappend="${(selectedStatus == null) ? ' chip active' : ' chip'}">All</a>
-      <a th:each="s : ${allStatuses}"
-         th:href="@{/admin/taproom(tab='kegs', status=${s})}"
-         th:text="${s}"
-         th:classappend="${(selectedStatus == s) ? ' chip active' : ' chip'}">RECEIVED</a>
+        </tbody>
+      </table>
     </div>
-    <ul>
+  </section>
+
+  <section class="page-section" th:if="${tab == 'kegs'}">
+    <div class="section-heading">
+      <div>
+        <h3>Available kegs</h3>
+        <p class="muted">Received inventory staged for tapping.</p>
+      </div>
+    </div>
+    <div class="filter-chip-row">
+      <span class="muted">Status:</span>
+      <a th:href="@{/admin/taproom(tab='kegs', taproomId=${taproom != null ? taproom.id : null})}"
+         th:classappend="${selectedStatus == null} ? ' filter-chip active' : ' filter-chip'">RECEIVED</a>
+      <a th:each="s : ${allStatuses}"
+         th:href="@{/admin/taproom(tab='kegs', status=${s}, taproomId=${taproom != null ? taproom.id : null})}"
+         th:text="${s}"
+         th:classappend="${selectedStatus == s} ? ' filter-chip active' : ' filter-chip'">STATUS</a>
+    </div>
+    <ul class="inventory-list">
       <li th:each="k : ${kegs}">
-        <span th:text="${k.serialNumber}">SER-001</span>:
-        <span th:text="${k.beer.name}">Beer</span>
-        — <span th:text="${k.size}">HALF_BARREL</span>
-        — <span class="badge" th:text="${k.status}"
-                th:classappend="${(k.status == T(com.mythictales.bms.taplist.domain.KegStatus).FILLED) ? ' green' :
-                                (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).DISTRIBUTED ? ' blue' :
-                                (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).RECEIVED ? ' purple' :
-                                (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).TAPPED ? ' orange' :
-                                (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).BLOWN ? ' red' : ' gray'))))}">
-          </span>
+        <div>
+          <strong th:text="${k.serialNumber}">SER-001</strong>
+          <span class="muted" th:text="${' · ' + k.beer.name + ' · ' + k.size}"></span>
+        </div>
+        <span class="badge" th:classappend="${k.status == T(com.mythictales.bms.taplist.domain.KegStatus).FILLED} ? ' green' :
+                                     (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).DISTRIBUTED ? ' blue' :
+                                     (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).RECEIVED ? ' purple' :
+                                     (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).TAPPED ? ' orange' :
+                                     (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).BLOWN ? ' red' : ' gray'))))"
+              th:text="${k.status}">STATUS</span>
       </li>
+      <li th:if="${#lists.isEmpty(kegs)}" class="muted">No kegs match the selected status.</li>
     </ul>
-
   </section>
 
-  <!-- Inbound Kegs -->
-  <section th:if="${tab == 'inbound'}">
-    <h2>Inbound Kegs (Awaiting Receipt)</h2>
-    <ul>
+  <section class="page-section" th:if="${tab == 'inbound'}">
+    <div class="section-heading">
+      <div>
+        <h3>Inbound kegs</h3>
+        <p class="muted">DISTRIBUTED kegs awaiting receipt.</p>
+      </div>
+    </div>
+    <ul class="inventory-list">
       <li th:each="k : ${inboundKegs}">
-        <span th:text="${k.serialNumber}">SER-002</span>:
-        <span th:text="${k.beer.name}">Beer</span> — <span th:text="${k.size}">HALF_BARREL</span>
-        <form method="post" th:action="@{'/admin/taproom/kegs/' + ${k.id} + '/receive'}" class="inline" style="margin-left:0.5rem;">
-          <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-          <button class="btn" type="submit">Receive</button>
+        <div>
+          <strong th:text="${k.serialNumber}">SER-002</strong>
+          <span class="muted" th:text="${' · ' + k.beer.name + ' · ' + k.size}"></span>
+        </div>
+        <form method="post" th:action="@{'/admin/taproom/kegs/' + ${k.id} + '/receive'}" class="form-inline form-inline--compact">
+          <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+          <div class="form-actions">
+            <button class="btn secondary" type="submit">Mark received</button>
+          </div>
         </form>
       </li>
+      <li th:if="${#lists.isEmpty(inboundKegs)}" class="muted">No inbound kegs right now.</li>
     </ul>
   </section>
 
-  <!-- Blown Kegs -->
-  <section th:if="${tab == 'blown'}">
-    <h2>Blown Kegs (Ready to Return)</h2>
-    <ul>
+  <section class="page-section" th:if="${tab == 'blown'}">
+    <div class="section-heading">
+      <div>
+        <h3>Blown kegs</h3>
+        <p class="muted">Ready for return to the brewery.</p>
+      </div>
+    </div>
+    <ul class="inventory-list">
       <li th:each="k : ${blownKegs}">
-        <span th:text="${k.serialNumber}">SER-003</span>:
-        <span th:text="${k.beer.name}">Beer</span> — <span th:text="${k.size}">HALF_BARREL</span>
-        <form method="post" th:action="@{'/admin/taproom/kegs/' + ${k.id} + '/return'}" class="inline" style="margin-left:0.5rem;">
-          <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-          <button class="btn" type="submit">Return to Brewery</button>
+        <div>
+          <strong th:text="${k.serialNumber}">SER-003</strong>
+          <span class="muted" th:text="${' · ' + k.beer.name + ' · ' + k.size}"></span>
+        </div>
+        <form method="post" th:action="@{'/admin/taproom/kegs/' + ${k.id} + '/return'}" class="form-inline form-inline--compact">
+          <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+          <div class="form-actions">
+            <button class="btn secondary" type="submit">Return to brewery</button>
+          </div>
         </form>
       </li>
+      <li th:if="${#lists.isEmpty(blownKegs)}" class="muted">No blown kegs waiting for pickup.</li>
     </ul>
   </section>
 
-  <!-- Users -->
-  <section th:if="${tab == 'users'}">
-    <h2>Users</h2>
-    <table class="table">
-      <thead>
+  <section class="page-section" th:if="${tab == 'users'}">
+    <div class="section-heading">
+      <div>
+        <h3>Taproom users</h3>
+        <p class="muted">Roles scoped to this taproom.</p>
+      </div>
+    </div>
+    <div class="table-wrapper">
+      <table class="table">
+        <thead>
         <tr><th>Username</th><th>Role</th></tr>
-      </thead>
-      <tbody>
+        </thead>
+        <tbody>
         <tr th:each="u : ${taproomUsers}">
           <td th:text="${u.username}">user</td>
-          <td th:text="${u.role}">role</td>
+          <td th:text="${#strings.replace(u.role,'ROLE_','')}">role</td>
         </tr>
-      </tbody>
-    </table>
+        <tr th:if="${#lists.isEmpty(taproomUsers)}">
+          <td class="muted" colspan="2">No users assigned to this taproom.</td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
   </section>
 
-  <!-- Events -->
-  <section th:if="${tab == 'events'}">
-    <h2>Events</h2>
-    <div class="alert muted" th:if="${#lists.isEmpty(events)}">No events yet.</div>
-    <table class="table" th:if="${!#lists.isEmpty(events)}">
-      <thead>
-      <tr>
-        <th>Time</th>
-        <th>Tap</th>
-        <th>Event</th>
-        <th>Ounces</th>
-        <th>Beer</th>
-        <th>Keg</th>
-        <th>By</th>
-      </tr>
-      </thead>
-      <tbody>
-      <tr th:each="e : ${events}">
-        <td th:text="${e.atTime}">2025-01-01T00:00:00Z</td>
-        <td th:text="${e.placement.tap.number}">1</td>
-        <td th:text="${e.type}">POUR</td>
-        <td th:text="${e.ounces} ?: '-'">16</td>
-        <td th:text="${e.placement.keg.beer.name}">IPA</td>
-        <td th:text="${e.placement.keg.id}">42</td>
-        <td th:text="${e.actor != null ? e.actor.username : '—'}">—</td>
-      </tr>
-      </tbody>
-    </table>
+  <section class="page-section" th:if="${tab == 'events'}">
+    <div class="section-heading">
+      <div>
+        <h3>Event log</h3>
+        <p class="muted">Review pours, blows, and maintenance activity.</p>
+      </div>
+    </div>
+    <div class="alert" th:if="${#lists.isEmpty(events)}">No events recorded.</div>
+    <div class="table-wrapper" th:if="${!#lists.isEmpty(events)}">
+      <table class="table">
+        <thead>
+        <tr><th>Time</th><th>Tap</th><th>Event</th><th>Ounces</th><th>Beer</th><th>Keg</th><th>By</th></tr>
+        </thead>
+        <tbody>
+        <tr th:each="e : ${events}">
+          <td th:text="${e.atTime}">2025-01-01T00:00:00Z</td>
+          <td th:text="${e.placement.tap.number}">1</td>
+          <td><span class="badge blue" th:text="${e.type}">POUR</span></td>
+          <td th:text="${e.ounces} ?: '-'">16</td>
+          <td th:text="${e.placement.keg.beer.name}">IPA</td>
+          <td th:text="${e.placement.keg.id}">42</td>
+          <td th:text="${e.actor != null ? e.actor.username : '—'}">—</td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
   </section>
-</main>
-    <div th:replace="~{fragments/footer :: footer}"></div>
+</section>
+
 <script>
-  (function(){
-    function ajaxify(form){
-      form.addEventListener('submit', function(e){
+  (function () {
+    function ajaxify(form) {
+      form.addEventListener('submit', function (e) {
         e.preventDefault();
         var fd = new FormData(form);
         var target = (e.submitter && e.submitter.getAttribute('formaction')) || form.getAttribute('action') || window.location.href;
@@ -248,36 +318,42 @@
           credentials: 'same-origin',
           headers: { 'X-Requested-With': 'XMLHttpRequest' },
           body: new URLSearchParams(fd)
-        }).then(function(){
-          // Refresh only the affected row if possible, else whole taplist section
-          var url = new URL(window.location.href);
-          url.searchParams.set('tab','taplist');
-          return fetch(url.toString(), { credentials: 'same-origin' })
-            .then(function(res){ return res.text(); })
-            .then(function(html){
-              var tmp = document.createElement('div');
-              tmp.innerHTML = html;
-              if (tapId) {
-                var srcRow = tmp.querySelector('#tap-row-' + tapId);
-                var dstRow = document.querySelector('#tap-row-' + tapId);
-                if (srcRow && dstRow) {
-                  dstRow.innerHTML = srcRow.innerHTML;
-                  attachAjax();
-                  return;
-                }
-              }
-              // fallback: replace taplist section
-              var src = tmp.querySelector('#taplistSection');
-              var dst = document.querySelector('#taplistSection');
-              if (src && dst) { dst.innerHTML = src.innerHTML; attachAjax(); }
+        })
+          .then(function () {
+            var url = new URL(window.location.href);
+            url.searchParams.set('tab', 'taplist');
+            return fetch(url.toString(), { credentials: 'same-origin' }).then(function (res) {
+              return res.text();
             });
-          .catch(function(err){ console.error('Update failed', err); });
+          })
+          .then(function (html) {
+            var tmp = document.createElement('div');
+            tmp.innerHTML = html;
+            if (tapId) {
+              var srcRow = tmp.querySelector('#tap-row-' + tapId);
+              var dstRow = document.querySelector('#tap-row-' + tapId);
+              if (srcRow && dstRow) {
+                dstRow.innerHTML = srcRow.innerHTML;
+                attachAjax();
+                return;
+              }
+            }
+            var src = tmp.querySelector('#taplistSection');
+            var dst = document.querySelector('#taplistSection');
+            if (src && dst) {
+              dst.innerHTML = src.innerHTML;
+              attachAjax();
+            }
+          })
+          .catch(function (err) {
+            console.error('Update failed', err);
+          });
       });
     }
-    function attachAjax(){
+    function attachAjax() {
       document.querySelectorAll('form.ajax-form').forEach(ajaxify);
     }
     attachAjax();
   })();
 </script>
-</body></html>
+</html>

--- a/src/main/resources/templates/admin/users.html
+++ b/src/main/resources/templates/admin/users.html
@@ -1,45 +1,64 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-<head>
-  <meta charset="UTF-8"/>
-  <title>Users</title>
-  <link rel="stylesheet" th:href="@{/css/app.css}"/>
-  <style>
-    .muted { color:#6b7280; }
-    .nowrap { white-space: nowrap; }
-    table.table { width: 100%; border-collapse: collapse; }
-    table.table th, table.table td { padding: .5rem .6rem; border-bottom: 1px solid #e5e7eb; }
-    table.table th { text-align: left; background: #f3f4f6; }
-  </style>
-  </head>
-<body>
-<header>
-  <h1>Users</h1>
-  <p class="muted">Admin-only view of all accounts and their associations.</p>
-  <p><a class="btn" th:href="@{/admin/site}">⟵ Back to Site Admin</a></p>
-  </header>
-<main>
-  <table class="table">
-    <thead>
-      <tr>
-        <th>Username</th>
-        <th>Role</th>
-        <th>Brewery</th>
-        <th>Taproom</th>
-        <th>Bar</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr th:each="u : ${users}">
-        <td class="nowrap" th:text="${u.username}">username</td>
-        <td class="nowrap" th:text="${u.role}">ROLE</td>
-        <td th:text="${u.brewery != null ? u.brewery.name : '-'}">-</td>
-        <td th:text="${u.taproom != null ? u.taproom.name : '-'}">-</td>
-        <td th:text="${u.bar != null ? u.bar.name : '-'}">-</td>
-      </tr>
-    </tbody>
-  </table>
-</main>
-<div th:replace="~{fragments/footer :: footer}"></div>
-</body>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="layouts/app :: layout('User Access', 'users', 'Admin view of accounts, roles, and brewery affiliations.', ~{::section[@id='page-content']})">
+<section id="page-content">
+  <section class="page-section">
+    <div class="card-grid">
+      <article class="metric-card">
+        <header>
+          <h3>Total accounts</h3>
+          <span class="metric-pill success" th:text="${#lists.size(users)} + ' active'">0 active</span>
+        </header>
+        <div class="metric-value" th:text="${#lists.size(users)}">0</div>
+        <footer class="muted">Accounts with access to Mythic Tales BMS.</footer>
+      </article>
+      <article class="metric-card">
+        <header>
+          <h3>Site admins</h3>
+          <span class="metric-pill warning">Scoped</span>
+        </header>
+        <div class="metric-value"
+             th:text="${users != null ? users.?[role == 'ROLE_SITE_ADMIN'].size() : 0}">0</div>
+        <footer class="muted">Users with global platform privileges.</footer>
+      </article>
+    </div>
+  </section>
+
+  <section class="page-section">
+    <div class="section-heading">
+      <div>
+        <h2>Account directory</h2>
+        <p class="muted">Sorted alphabetically by username with linked affiliations.</p>
+      </div>
+    </div>
+    <div class="table-wrapper">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Username</th>
+            <th>Role</th>
+            <th>Brewery</th>
+            <th>Taproom</th>
+            <th>Bar</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr th:each="u : ${users}">
+            <td class="nowrap" th:text="${u.username}">username</td>
+            <td>
+              <span th:text="${#strings.replace(u.role,'ROLE_','')}"
+                    th:class="${u.role} == 'ROLE_SITE_ADMIN' ? 'badge orange' : 'badge blue'}">ROLE</span>
+            </td>
+            <td th:text="${u.brewery != null ? u.brewery.name : '-'}">-</td>
+            <td th:text="${u.taproom != null ? u.taproom.name : '-'}">-</td>
+            <td th:text="${u.bar != null ? u.bar.name : '-'}">-</td>
+          </tr>
+          <tr th:if="${#lists.isEmpty(users)}">
+            <td class="muted" colspan="5">No users found.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</section>
 </html>

--- a/src/main/resources/templates/admin/venue.html
+++ b/src/main/resources/templates/admin/venue.html
@@ -1,37 +1,81 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-<head>
-  <meta charset="UTF-8"/>
-  <title th:text="'Venue Admin — ' + ${venue != null ? venue.name : 'Unknown'}">Venue Admin</title>
-  <link rel="stylesheet" th:href="@{/css/app.css}"/>
-</head>
-<body>
-  <header>
-    <h1 th:text="'Venue Admin — ' + ${venue != null ? venue.name : 'Unknown'}">Venue Admin</h1>
-    <div class="toolbar">
-      <a class="btn" th:if="${venue != null}" th:href="@{'/admin/venue/' + ${venue.id} + '/events'}">View Events</a>
-      <a class="btn ghost" th:if="${venue != null}" th:href="@{'/taplist?venueId=' + ${venue.id}}">View Taplist</a>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="layouts/app :: layout($ {'Venue Operations · ' + (venue != null ? venue.name : 'Venue')}, 'taproom', 'Monitor tap health and historical activity for this venue.', ~{::section[@id='page-content']})">
+<section id="page-content">
+  <section class="page-section">
+    <div class="card-grid">
+      <article class="metric-card">
+        <header>
+          <h3>Tap handles</h3>
+          <span class="metric-pill success" th:text="${tapCount} + ' total'">0 total</span>
+        </header>
+        <div class="metric-value" th:text="${tapCount}">0</div>
+        <footer class="muted">Tap handles assigned to this venue.</footer>
+      </article>
+      <article class="metric-card">
+        <header>
+          <h3>Pouring now</h3>
+          <span class="metric-pill warning" th:text="${activeTapCount} + ' active'">0 active</span>
+        </header>
+        <div class="metric-value" th:text="${activeTapCount}">0</div>
+        <footer class="muted">Taps currently serving beer.</footer>
+      </article>
+      <article class="metric-card">
+        <header>
+          <h3>Low alerts</h3>
+          <span class="metric-pill critical" th:text="${lowTapAlertCount} + ' flagged'">0 flagged</span>
+        </header>
+        <div class="metric-value" th:text="${lowTapAlertCount}">0</div>
+        <footer class="muted">Kegs below 10% capacity.</footer>
+      </article>
     </div>
-    <p>
-      <a class="btn" th:href="@{/admin/brewery}">⟵ Back to Brewery Admin</a>
-    </p>
-  </header>
-  <main>
-  <h2>Taps</h2>
-  <table class="table">
-    <thead><tr><th>#</th><th>Beer</th><th>%</th></tr></thead>
-    <tbody>
-      <tr th:each="t : ${taps}">
-        <td th:text="${t.number}">1</td>
-        <td>
-          <span th:if="${t.keg != null}" th:text="${t.keg.beer.name}">Beer</span>
-          <span th:if="${t.keg == null}"><em>Empty</em></span>
-        </td>
-        <td th:text="${t.keg != null ? t.keg.fillPercent : 0}">0</td>
-      </tr>
-    </tbody>
-  </table>
-  </main>
-  <div th:replace="~{fragments/footer :: footer}"></div>
-  </body>
+  </section>
+
+  <section class="page-section">
+    <div class="section-heading">
+      <div>
+        <h2 th:text="${venue != null ? venue.name : 'Venue'}">Venue</h2>
+        <p class="muted">Check tap assignments and pivot to event history or public taplist.</p>
+      </div>
+      <div class="actions">
+        <a class="btn ghost" th:if="${venue != null}" th:href="@{'/admin/venue/' + ${venue.id} + '/events'}">View events</a>
+        <a class="btn ghost" th:if="${venue != null}" th:href="@{'/taplist?venueId=' + ${venue.id}}">Taplist</a>
+        <a class="btn ghost" th:href="@{/admin/brewery}">Back to brewery</a>
+      </div>
+    </div>
+
+    <div class="table-wrapper">
+      <table class="table">
+        <thead>
+        <tr>
+          <th>Tap</th>
+          <th>Beer</th>
+          <th>Fill</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="t : ${taps}" th:classappend="${t.keg != null && t.keg.fillPercent != null && t.keg.fillPercent <= 10} ? 'is-low' : ''">
+          <td th:text="${t.number}">1</td>
+          <td>
+            <span th:if="${t.keg != null}">
+              <strong th:text="${t.keg.beer.name}">Beer</strong>
+              <span class="muted" th:text="${t.keg.beer.style != null ? ' · ' + t.keg.beer.style : ''}"></span>
+            </span>
+            <span th:if="${t.keg == null}" class="muted">Empty</span>
+          </td>
+          <td>
+            <div th:if="${t.keg != null}" class="fillbar">
+              <div class="fill" th:style="${'width:' + t.keg.fillPercent + '%'}"></div>
+            </div>
+            <span class="muted" th:text="${t.keg != null ? t.keg.fillPercent + '%' : '-'}">%</span>
+          </td>
+        </tr>
+        <tr th:if="${#lists.isEmpty(taps)}">
+          <td class="muted" colspan="3">No taps configured for this venue.</td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</section>
 </html>

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -1,20 +1,12 @@
-<!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-  <body>
-    <div th:fragment="footer">
-      <footer class="site-footer">
-        <div class="footer-inner">
-          <span>Logged in as </span>
-          <strong th:text="${currentUser != null ? currentUser.username : 'guest'}">guest</strong>
-          <span th:if="${currentUser != null}">
-            • Role:
-            <span th:text="${#strings.replace(currentUser.authorities[0].authority,'ROLE_','')}">ROLE</span>
-          </span>
-          <span style="margin-left:0.75rem" th:if="${#authentication?.authenticated}">
-            <a class="btn ghost" th:href="@{/logout}">Logout</a>
-          </span>
-        </div>
-      </footer>
+<div th:fragment="footer">
+  <footer class="app-footer">
+    <div class="footer-meta">
+      <span th:text="${currentUser != null ? 'Signed in as ' : 'Not signed in'}">Signed in as</span>
+      <strong th:if="${currentUser != null}" th:text="${currentUser.username}">user</strong>
+      <span th:if="${currentUser != null}" class="footer-role" th:text="${#strings.replace(currentUser.authorities[0].authority,'ROLE_','')}">ROLE</span>
     </div>
-  </body>
-</html>
+    <div class="footer-actions" th:if="${#authentication?.authenticated}">
+      <a class="btn ghost" th:href="@{/logout}">Logout</a>
+    </div>
+  </footer>
+</div>

--- a/src/main/resources/templates/layouts/app.html
+++ b/src/main/resources/templates/layouts/app.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:fragment="layout(pageTitle, activeSection, pageSubtitle, content)">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title th:text="${pageTitle != null ? pageTitle + ' · Mythic Tales BMS' : 'Mythic Tales BMS'}">Mythic Tales BMS</title>
+  <link rel="stylesheet" th:href="@{/css/app.css}" />
+</head>
+<body class="app-shell">
+  <div class="app-frame">
+    <aside class="app-nav" aria-label="Primary navigation">
+      <div class="nav-brand">
+        <div class="brand-mark">Mythic Tales</div>
+        <div class="brand-app">Brewing Management</div>
+      </div>
+      <div class="nav-section">
+        <p class="nav-label">Overview</p>
+        <a th:href="@{/admin/site}" th:classappend="${activeSection} == 'site' ? ' active' : ''">Control Center</a>
+        <a th:href="@{/admin/users}" th:classappend="${activeSection} == 'users' ? ' active' : ''">User Access</a>
+      </div>
+      <div class="nav-section">
+        <p class="nav-label">Operations</p>
+        <a th:href="@{/admin/brewery}" th:classappend="${activeSection} == 'brewery' ? ' active' : ''">Breweries</a>
+        <a th:href="@{/admin/taproom}" th:classappend="${activeSection} == 'taproom' ? ' active' : ''">Taprooms</a>
+        <a th:href="@{/admin/bar}" th:classappend="${activeSection} == 'bar' ? ' active' : ''">Bars</a>
+      </div>
+      <div class="nav-section">
+        <p class="nav-label">Catalog</p>
+        <a th:href="@{/admin/beer}" th:classappend="${activeSection} == 'beer' ? ' active' : ''">Beer Library</a>
+        <a th:href="@{/admin/catalog/recipes}" th:classappend="${activeSection} == 'recipes' ? ' active' : ''">Recipes</a>
+      </div>
+      <div class="nav-footer" th:if="${currentUser != null}">
+        <p class="nav-user-label">Signed in</p>
+        <div class="nav-user">
+          <span class="nav-user-name" th:text="${currentUser.username}">user</span>
+          <span class="nav-user-role" th:text="${#strings.replace(currentUser.authorities[0].authority,'ROLE_','')}">ROLE</span>
+        </div>
+      </div>
+    </aside>
+
+    <div class="app-main">
+      <header class="app-topbar">
+        <div class="topbar-titles">
+          <h1 th:text="${pageTitle != null ? pageTitle : 'Mythic Tales BMS'}">Mythic Tales BMS</h1>
+          <p class="topbar-subtitle" th:if="${pageSubtitle != null}" th:text="${pageSubtitle}">Subtitle</p>
+        </div>
+        <div class="topbar-actions">
+          <a class="btn ghost" th:href="@{/logout}" th:if="${#authentication?.authenticated}">Logout</a>
+        </div>
+      </header>
+      <main class="app-content" th:insert="${content}"></main>
+      <div class="app-footer-placeholder" th:replace="~{fragments/footer :: footer}"></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/main/resources/templates/taplist/list.html
+++ b/src/main/resources/templates/taplist/list.html
@@ -85,7 +85,7 @@
                 </select>
               </label>
               <button class="btn" type="submit">Pour</button>
-              <button class="btn danger" type="submit" th:formaction="@{'/taps/' + ${t.id} + '/blow'}">Blow</button>
+              <button class="btn critical outline" type="submit" th:formaction="@{'/taps/' + ${t.id} + '/blow'}">Blow</button>
             </form>
           </div>
           <div th:if="${t.keg == null}" class="actions">

--- a/src/main/resources/templates/ui-playground/index.html
+++ b/src/main/resources/templates/ui-playground/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8" />
+  <title>Mythic Tales UI Playground</title>
+  <link rel="stylesheet" th:href="@{/css/app.css}" />
+  <link rel="stylesheet" th:href="@{/css/ui-playground.css}" />
+</head>
+<body class="ui-playground">
+<div class="playground-shell">
+  <aside class="playground-nav">
+    <div class="nav-header">
+      <div class="product-mark">Mythic Tales BMS</div>
+      <p class="nav-subtitle">Storybook-style catalog of enterprise UI components.</p>
+    </div>
+    <nav class="story-list" aria-label="Component stories">
+      <a th:each="story : ${stories}"
+         th:href="@{/ui/playground(story=${story.id})}"
+         th:text="${story.label}"
+         th:classappend="${story.id == selectedStory} ? 'active' : ''"></a>
+    </nav>
+    <p class="nav-description" th:text="${selectedStoryMeta.description}"></p>
+  </aside>
+
+  <main class="playground-stage">
+    <header class="stage-header">
+      <h1 th:text="${selectedStoryMeta.label}">Foundations</h1>
+      <p class="stage-context">Profiles enterprise-ready colors, spacing, and components. Each section references shared design tokens before full implementation across admin screens.</p>
+    </header>
+
+    <section class="stage-body" th:switch="${selectedStory}">
+      <div th:case="'foundations'" th:replace="~{ui-playground/stories/foundations :: story}"></div>
+      <div th:case="'buttons'" th:replace="~{ui-playground/stories/buttons :: story}"></div>
+      <div th:case="'cards'" th:replace="~{ui-playground/stories/cards :: story}"></div>
+      <div th:case="'tables'" th:replace="~{ui-playground/stories/tables :: story}"></div>
+      <div th:case="'forms'" th:replace="~{ui-playground/stories/forms :: story}"></div>
+      <div th:case="'overlays'" th:replace="~{ui-playground/stories/overlays :: story}"></div>
+      <div th:case="'visualizations'" th:replace="~{ui-playground/stories/visualizations :: story}"></div>
+    </section>
+  </main>
+</div>
+<div th:replace="~{fragments/footer :: footer}"></div>
+</body>
+</html>

--- a/src/main/resources/templates/ui-playground/stories/buttons.html
+++ b/src/main/resources/templates/ui-playground/stories/buttons.html
@@ -1,0 +1,28 @@
+<div th:fragment="story">
+  <section class="story-section">
+    <h2>Primary Actions</h2>
+    <div class="story-grid">
+      <button class="story-btn btn-primary">Create Brew Run</button>
+      <button class="story-btn btn-primary" disabled>Schedule Batch</button>
+      <button class="story-btn btn-primary icon">Save Draft<i class="icon-chevron"></i></button>
+    </div>
+    <p class="muted">Primary buttons rely on the accent color; disabled state dims to 40% opacity.</p>
+  </section>
+
+  <section class="story-section">
+    <h2>Secondary &amp; Ghost</h2>
+    <div class="story-grid">
+      <button class="story-btn btn-secondary">Assign Brewer</button>
+      <button class="story-btn btn-ghost">Export CSV</button>
+      <button class="story-btn btn-ghost danger">Stop Batch</button>
+    </div>
+  </section>
+
+  <section class="story-section">
+    <h2>Destructive</h2>
+    <div class="story-grid">
+      <button class="story-btn btn-critical">Archive Taproom</button>
+      <button class="story-btn btn-critical outline">Remove Recipe</button>
+    </div>
+  </section>
+</div>

--- a/src/main/resources/templates/ui-playground/stories/cards.html
+++ b/src/main/resources/templates/ui-playground/stories/cards.html
@@ -1,0 +1,47 @@
+<div th:fragment="story">
+  <section class="story-section">
+    <h2>Metric Cards</h2>
+    <div class="card-row">
+      <article class="metric-card">
+        <header>
+          <span class="metric-label">Active Fermenters</span>
+          <span class="metric-pill success">Stable</span>
+        </header>
+        <div class="metric-value">12</div>
+        <footer>↑ 2 vs last week</footer>
+      </article>
+      <article class="metric-card">
+        <header>
+          <span class="metric-label">Pending Transfers</span>
+          <span class="metric-pill warning">Action Needed</span>
+        </header>
+        <div class="metric-value">5</div>
+        <footer>Oldest: 3 days</footer>
+      </article>
+    </div>
+  </section>
+
+  <section class="story-section">
+    <h2>Content Cards</h2>
+    <div class="card-row">
+      <article class="content-card">
+        <header>
+          <div>
+            <h3>Batch QA Checklist</h3>
+            <p class="muted">Validate gravity, temperature, and sanitation before transfer.</p>
+          </div>
+          <button class="story-btn btn-secondary">Review</button>
+        </header>
+        <ul class="card-list">
+          <li>Fermentation log needs signature</li>
+          <li>Cooling loop inspection pending</li>
+          <li>Notify distribution of ETA</li>
+        </ul>
+        <footer>
+          <button class="story-btn btn-ghost">Dismiss</button>
+          <button class="story-btn btn-primary">Complete tasks</button>
+        </footer>
+      </article>
+    </div>
+  </section>
+</div>

--- a/src/main/resources/templates/ui-playground/stories/forms.html
+++ b/src/main/resources/templates/ui-playground/stories/forms.html
@@ -1,0 +1,68 @@
+<div th:fragment="story">
+  <section class="story-section">
+    <h2>Form Controls</h2>
+    <form class="storybook-form">
+      <div class="form-group">
+        <label for="brew-name">Brew Name</label>
+        <input id="brew-name" type="text" value="Mythic Pilsner" />
+        <p class="field-hint">Visible to all taprooms in the brewery network.</p>
+      </div>
+      <div class="form-group">
+        <label for="status">Batch Status</label>
+        <div class="select-wrap">
+          <select id="status">
+            <option>Fermenting</option>
+            <option>Conditioning</option>
+            <option>Packaging</option>
+            <option>Cellared</option>
+          </select>
+        </div>
+      </div>
+      <div class="form-grid">
+        <div class="form-group">
+          <label for="volume">Planned Volume (bbl)</label>
+          <input id="volume" type="number" value="30" />
+        </div>
+        <div class="form-group">
+          <label for="temp">Target Temp (°F)</label>
+          <input id="temp" type="number" value="68" />
+        </div>
+        <div class="form-group">
+          <label for="target-date">Transfer Date</label>
+          <input id="target-date" type="date" value="2025-10-12" />
+        </div>
+      </div>
+    </form>
+  </section>
+
+  <section class="story-section">
+    <h2>Validation States</h2>
+    <div class="form-grid">
+      <div class="form-group has-error">
+        <label for="gravity">Original Gravity</label>
+        <input id="gravity" type="text" value="" placeholder="e.g., 1.056" />
+        <p class="field-error">Gravity reading required before starting the brew run.</p>
+      </div>
+      <div class="form-group has-warning">
+        <label for="abv">ABV (calculated)</label>
+        <input id="abv" type="text" value="8.4%" />
+        <p class="field-warning">ABV exceeds style guideline by 1.2%.</p>
+      </div>
+      <div class="form-group has-success">
+        <label for="ph">pH Reading</label>
+        <input id="ph" type="text" value="4.3" />
+        <p class="field-success">Within range for this recipe.</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="story-section">
+    <h2>Filter Chips</h2>
+    <div class="filter-chip-row">
+      <button class="filter-chip active">Active Batches<i></i></button>
+      <button class="filter-chip">Needs QA<i></i></button>
+      <button class="filter-chip">Distribution Hold<i></i></button>
+      <button class="filter-chip">Past Due<i></i></button>
+    </div>
+  </section>
+</div>

--- a/src/main/resources/templates/ui-playground/stories/foundations.html
+++ b/src/main/resources/templates/ui-playground/stories/foundations.html
@@ -1,0 +1,94 @@
+<div th:fragment="story">
+  <section class="story-section">
+    <h2>Color Tokens</h2>
+    <div class="swatch-grid">
+      <div class="swatch" style="--swatch-color:#2E5AAC">
+        <span class="swatch-chip"></span>
+        <div>
+          <strong>Primary 500</strong>
+          <div>#2E5AAC</div>
+          <div>Buttons, links, focus</div>
+        </div>
+      </div>
+      <div class="swatch" style="--swatch-color:#249F7F">
+        <span class="swatch-chip"></span>
+        <div>
+          <strong>Success 500</strong>
+          <div>#249F7F</div>
+          <div>Success states</div>
+        </div>
+      </div>
+      <div class="swatch" style="--swatch-color:#C97A1E">
+        <span class="swatch-chip"></span>
+        <div>
+          <strong>Warning 500</strong>
+          <div>#C97A1E</div>
+          <div>Alerts, brewing thresholds</div>
+        </div>
+      </div>
+      <div class="swatch" style="--swatch-color:#C73E3E">
+        <span class="swatch-chip"></span>
+        <div>
+          <strong>Critical 500</strong>
+          <div>#C73E3E</div>
+          <div>Blocking incidents</div>
+        </div>
+      </div>
+      <div class="swatch" style="--swatch-color:#F5F7FB; color:#111827">
+        <span class="swatch-chip"></span>
+        <div>
+          <strong>Surface 100</strong>
+          <div>#F5F7FB</div>
+          <div>Default canvas</div>
+        </div>
+      </div>
+      <div class="swatch" style="--swatch-color:#1E2432">
+        <span class="swatch-chip"></span>
+        <div>
+          <strong>Surface 900</strong>
+          <div>#1E2432</div>
+          <div>Shell, dark cards</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="story-section">
+    <h2>Typography Scale</h2>
+    <div class="type-stack">
+      <div>
+        <div class="type-label">Display / 32px / 700</div>
+        <div class="type-sample type-display">Critical Production Alert</div>
+      </div>
+      <div>
+        <div class="type-label">Headline / 24px / 600</div>
+        <div class="type-sample type-headline">Taproom KPIs</div>
+      </div>
+      <div>
+        <div class="type-label">Title / 20px / 600</div>
+        <div class="type-sample type-title">Brew Cycle Overview</div>
+      </div>
+      <div>
+        <div class="type-label">Body / 16px / 400</div>
+        <div class="type-sample type-body">Use this size for descriptive copy and insights.</div>
+      </div>
+      <div>
+        <div class="type-label">Caption / 14px / 500</div>
+        <div class="type-sample type-caption">Metadata, tags, secondary actions.</div>
+      </div>
+    </div>
+  </section>
+
+  <section class="story-section">
+    <h2>Spacing Grid</h2>
+    <div class="spacing-row">
+      <div class="spacing-chip" style="--space-size:4px">4</div>
+      <div class="spacing-chip" style="--space-size:8px">8</div>
+      <div class="spacing-chip" style="--space-size:12px">12</div>
+      <div class="spacing-chip" style="--space-size:16px">16</div>
+      <div class="spacing-chip" style="--space-size:24px">24</div>
+      <div class="spacing-chip" style="--space-size:32px">32</div>
+    </div>
+    <p class="muted">Spacing tokens set the rhythm for padding, margins, and grid gaps.</p>
+  </section>
+</div>

--- a/src/main/resources/templates/ui-playground/stories/overlays.html
+++ b/src/main/resources/templates/ui-playground/stories/overlays.html
@@ -1,0 +1,78 @@
+<div th:fragment="story">
+  <section class="story-section">
+    <h2>Modal Dialog</h2>
+    <div class="modal-preview">
+      <div class="modal-window">
+        <header>
+          <h3>Schedule Transfer</h3>
+          <span class="modal-meta">Batch BR-2025-091</span>
+        </header>
+        <div class="modal-body">
+          <p>Confirm the transfer to the bright tank. Notify packaging when the schedule is locked.</p>
+          <div class="modal-checklist">
+            <label><input type="checkbox" checked /> QA sign-off recorded</label>
+            <label><input type="checkbox" /> Cellar temperature adjusted</label>
+            <label><input type="checkbox" /> Distribution notified</label>
+          </div>
+        </div>
+        <footer>
+          <button class="story-btn btn-ghost">Cancel</button>
+          <button class="story-btn btn-primary">Confirm transfer</button>
+        </footer>
+      </div>
+    </div>
+  </section>
+
+  <section class="story-section">
+    <h2>Slide-over Panel</h2>
+    <div class="slideover-preview">
+      <aside class="slideover">
+        <header>
+          <div>
+            <h3>Taproom Snapshot</h3>
+            <p class="muted">Dockside Taproom • Updated 5 minutes ago</p>
+          </div>
+          <button class="slideover-close">×</button>
+        </header>
+        <div class="slideover-body">
+          <dl>
+            <div>
+              <dt>Active taps</dt>
+              <dd>18 / 24</dd>
+            </div>
+            <div>
+              <dt>Low keg alerts</dt>
+              <dd><span class="metric-pill warning">3</span></dd>
+            </div>
+            <div>
+              <dt>Events tonight</dt>
+              <dd>Tap takeover at 7:00 PM</dd>
+            </div>
+          </dl>
+        </div>
+        <footer>
+          <button class="story-btn btn-secondary">View taproom</button>
+          <button class="story-btn btn-ghost">Mute alerts</button>
+        </footer>
+      </aside>
+    </div>
+  </section>
+
+  <section class="story-section">
+    <h2>Toast Notifications</h2>
+    <div class="toast-stack">
+      <div class="toast success">
+        <strong>Batch scheduled</strong>
+        <span>Transfer BR-2025-091 moved to 14:00 today.</span>
+      </div>
+      <div class="toast warning">
+        <strong>Low keg alert</strong>
+        <span>Tap 12 at Riverfront is below 8% capacity.</span>
+      </div>
+      <div class="toast critical">
+        <strong>Compliance hold</strong>
+        <span>QC sample missing for batch BR-2025-086.</span>
+      </div>
+    </div>
+  </section>
+</div>

--- a/src/main/resources/templates/ui-playground/stories/tables.html
+++ b/src/main/resources/templates/ui-playground/stories/tables.html
@@ -1,0 +1,61 @@
+<div th:fragment="story">
+  <section class="story-section">
+    <h2>Operations Table</h2>
+    <div class="table-wrapper">
+      <div class="table-toolbar">
+        <div class="toolbar-left">
+          <button class="story-btn btn-ghost">Bulk assign</button>
+          <button class="story-btn btn-ghost">Export</button>
+        </div>
+        <div class="toolbar-right">
+          <input class="table-search" placeholder="Search batches" />
+          <select>
+            <option>Last 7 days</option>
+            <option>Last 30 days</option>
+          </select>
+        </div>
+      </div>
+      <table class="storybook-table">
+        <thead>
+          <tr>
+            <th>Batch</th>
+            <th>Status</th>
+            <th>Volume</th>
+            <th>Assigned To</th>
+            <th>Updated</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>BR-2025-091</td>
+            <td><span class="metric-pill success">Fermenting</span></td>
+            <td>30 bbl</td>
+            <td>Riverfront</td>
+            <td>Oct 9, 09:24</td>
+          </tr>
+          <tr>
+            <td>BR-2025-092</td>
+            <td><span class="metric-pill warning">Cooling</span></td>
+            <td>18 bbl</td>
+            <td>Production HQ</td>
+            <td>Oct 9, 08:03</td>
+          </tr>
+          <tr>
+            <td>BR-2025-093</td>
+            <td><span class="metric-pill critical">Hold</span></td>
+            <td>12 bbl</td>
+            <td>Dockside</td>
+            <td>Oct 8, 21:17</td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="table-footer">
+        <div class="muted">Showing 1-3 of 18 batches</div>
+        <div class="table-pagination">
+          <button class="story-btn btn-ghost" disabled>Prev</button>
+          <button class="story-btn btn-ghost">Next</button>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>

--- a/src/main/resources/templates/ui-playground/stories/visualizations.html
+++ b/src/main/resources/templates/ui-playground/stories/visualizations.html
@@ -1,0 +1,45 @@
+<div th:fragment="story">
+  <section class="story-section">
+    <h2>Production Metrics</h2>
+    <div class="viz-grid">
+      <article class="viz-card">
+        <header>
+          <h3>Fermentation Pace</h3>
+          <span class="metric-pill success">+6%</span>
+        </header>
+        <div class="sparkline" aria-hidden="true">
+          <svg viewBox="0 0 120 40" role="img">
+            <polyline points="0,28 20,18 40,22 60,12 80,16 100,6 120,10" />
+          </svg>
+        </div>
+        <footer>Trend based on last 14 days of completed batches.</footer>
+      </article>
+      <article class="viz-card">
+        <header>
+          <h3>Tank Capacity</h3>
+          <span class="muted">68% utilized</span>
+        </header>
+        <div class="capacity-ring">
+          <svg viewBox="0 0 120 120">
+            <circle class="bg" cx="60" cy="60" r="52" />
+            <circle class="fg" cx="60" cy="60" r="52" stroke-dasharray="327" stroke-dashoffset="105" />
+            <text x="60" y="66" text-anchor="middle">68%</text>
+          </svg>
+        </div>
+        <footer>Fermenters 9/12 • Conditioning 3/6 • Bright tanks 2/4.</footer>
+      </article>
+      <article class="viz-card">
+        <header>
+          <h3>Distribution Readiness</h3>
+          <span class="muted">by status</span>
+        </header>
+        <div class="segmented-bar">
+          <div class="segment ready" style="--segment:48%">Ready 48%</div>
+          <div class="segment staging" style="--segment:32%">Staging 32%</div>
+          <div class="segment hold" style="--segment:20%">Hold 20%</div>
+        </div>
+        <footer>Includes all packaged batches scheduled this week.</footer>
+      </article>
+    </div>
+  </section>
+</div>

--- a/test/smoke-test/tmp/taplist.html
+++ b/test/smoke-test/tmp/taplist.html
@@ -74,7 +74,7 @@
                 </select>
               </label>
               <button class="btn" type="submit">Pour</button>
-              <button class="btn danger" type="submit" formaction="/taps/1/blow">Blow</button>
+              <button class="btn critical outline" type="submit" formaction="/taps/1/blow">Blow</button>
             </form>
           </div>
           
@@ -141,7 +141,7 @@
                 </select>
               </label>
               <button class="btn" type="submit">Pour</button>
-              <button class="btn danger" type="submit" formaction="/taps/2/blow">Blow</button>
+              <button class="btn critical outline" type="submit" formaction="/taps/2/blow">Blow</button>
             </form>
           </div>
           


### PR DESCRIPTION
## Summary
- apply enterprise layout shell across admin surfaces and refresh component styling
- add dev-only UI playground for tokens, components, and data viz demos
- surface live metrics in site, brewery, taproom, bar, venue, and catalog dashboards

## Testing
- mvn -q -DskipTests compile
- manual: spring-boot:run (dev) → /ui/playground, /admin/site, /admin/brewery, /admin/taproom