### PR TITLE
Fix taplist projection migration for Postgres

### DIFF
--- a/docs/tech/reviewbranches/20250919-taplist-projection-double.md
+++ b/docs/tech/reviewbranches/20250919-taplist-projection-double.md
@@ -1,0 +1,14 @@
+# feature/platform/taplist-projection-double
+
+- Area: platform
+- Owner: techlead
+- Task: docs/techtasks/000-technical-backlog.md (Flyway + staging parity)
+- Summary: Fix taplist projection migration to use Postgres-compatible double precision types.
+- Scope: src/main/resources/db/migration/V5__taplist_projections.sql
+- Risk: low
+- Test Plan: `SPRING_PROFILES_ACTIVE=staging mvn -Dflyway.cleanDisabled=false flyway:clean flyway:migrate` (if safe) or run staging startup after container reset
+- Status: in-progress
+- PR: <tbd>
+
+## Notes
+- Postgres rejects `double`; use `double precision` for numeric columns in projection table.

--- a/src/main/resources/db/migration/V5__taplist_projections.sql
+++ b/src/main/resources/db/migration/V5__taplist_projections.sql
@@ -5,12 +5,11 @@ create table if not exists taplist_view (
   venue_id bigint,
   beer_name varchar(255),
   style varchar(255),
-  abv double,
-  remaining_ounces double,
-  total_ounces double,
+  abv double precision,
+  remaining_ounces double precision,
+  total_ounces double precision,
   fill_percent integer,
   updated_at timestamp not null
 );
 
 create index if not exists idx_tlv_venue on taplist_view(venue_id);
-


### PR DESCRIPTION
## Summary
- change taplist_view Flyway migration columns from `double` to `double precision`
- document the staging fix in review entry 20250919-taplist-projection-double

## Testing
- mvn -q -DskipTests compile