### PR TITLE
Wrap Thymeleaf layout fragments in ~{}

### DIFF
--- a/docs/tech/reviewbranches/20250919-thymeleaf-fragment-syntax.md
+++ b/docs/tech/reviewbranches/20250919-thymeleaf-fragment-syntax.md
@@ -1,0 +1,14 @@
+# feature/platform/thymeleaf-fragment-syntax
+
+- Area: platform
+- Owner: techlead
+- Task: docs/techtasks/000-technical-backlog.md (Thymeleaf modernization)
+- Summary: Wrap layout fragment expressions with `~{}` to silence Thymeleaf 3.1 warnings and prevent parse errors.
+- Scope: src/main/resources/templates/admin/*.html
+- Risk: low
+- Test Plan: `mvn -q -DskipTests compile`, then hit /admin/site in dev profile.
+- Status: in-progress
+- PR: <tbd>
+
+## Notes
+- Thymeleaf 3.1 warns when fragment expressions omit the `~{}` wrapper; upcoming versions will fail outright, so update now.

--- a/src/main/resources/templates/admin/bar.html
+++ b/src/main/resources/templates/admin/bar.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-      th:replace="layouts/app :: layout('Bar Operations', 'bar', 'Live view of tap health and keg status for this bar location.', ~{::section[@id='page-content']})">
+      th:replace="~{layouts/app :: layout('Bar Operations', 'bar', 'Live view of tap health and keg status for this bar location.', ~{::section[@id='page-content']})}">
 <section id="page-content">
   <section class="page-section">
     <div class="card-grid">

--- a/src/main/resources/templates/admin/beer.html
+++ b/src/main/resources/templates/admin/beer.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-      th:replace="layouts/app :: layout('Beer Library', 'beer', 'Link brewery beers to BJCP guidelines and keep style metadata current.', ~{::section[@id='page-content']})">
+      th:replace="~{layouts/app :: layout('Beer Library', 'beer', 'Link brewery beers to BJCP guidelines and keep style metadata current.', ~{::section[@id='page-content']})}">
 <section id="page-content">
   <section class="page-section">
     <div class="card-grid">

--- a/src/main/resources/templates/admin/brewery.html
+++ b/src/main/resources/templates/admin/brewery.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-      th:replace="layouts/app :: layout('Brewery Operations', 'brewery', 'Coordinate taprooms, kegs, and distribution for this brewery.', ~{::section[@id='page-content']})">
+      th:replace="~{layouts/app :: layout('Brewery Operations', 'brewery', 'Coordinate taprooms, kegs, and distribution for this brewery.', ~{::section[@id='page-content']})}">
 <section id="page-content">
   <section class="page-section">
     <div class="card-grid">

--- a/src/main/resources/templates/admin/catalog-recipe-edit.html
+++ b/src/main/resources/templates/admin/catalog-recipe-edit.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-      th:replace="layouts/app :: layout(${recipe != null ? 'Recipe · ' + recipe.name : 'Recipe Editor'}, 'recipes', 'Brew house details and ingredient inventory.', ~{::section[@id='page-content']})">
+      th:replace="~{layouts/app :: layout(${recipe != null ? 'Recipe · ' + recipe.name : 'Recipe Editor'}, 'recipes', 'Brew house details and ingredient inventory.', ~{::section[@id='page-content']})}">
 <section id="page-content">
   <section class="page-section">
     <div class="section-heading">

--- a/src/main/resources/templates/admin/catalog-recipes.html
+++ b/src/main/resources/templates/admin/catalog-recipes.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-      th:replace="layouts/app :: layout('Recipe Catalog', 'recipes', 'Brewery recipes and production metadata.', ~{::section[@id='page-content']})">
+      th:replace="~{layouts/app :: layout('Recipe Catalog', 'recipes', 'Brewery recipes and production metadata.', ~{::section[@id='page-content']})}">
 <section id="page-content">
   <section class="page-section">
     <div class="card-grid">

--- a/src/main/resources/templates/admin/events.html
+++ b/src/main/resources/templates/admin/events.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-      th:replace="layouts/app :: layout(${'Keg Events · ' + (venue != null ? venue.name : 'Venue')}, 'taproom', 'Audit trail for pours, blows, and maintenance at this venue.', ~{::section[@id='page-content']})">
+      th:replace="~{layouts/app :: layout(${'Keg Events · ' + (venue != null ? venue.name : 'Venue')}, 'taproom', 'Audit trail for pours, blows, and maintenance at this venue.', ~{::section[@id='page-content']})}">
 <section id="page-content">
   <section class="page-section">
     <div class="card-grid">

--- a/src/main/resources/templates/admin/site.html
+++ b/src/main/resources/templates/admin/site.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-      th:replace="layouts/app :: layout('Control Center', 'site', 'Cross-brewery visibility and admin shortcuts for the Mythic Tales network.', ~{::section[@id='page-content']})">
+      th:replace="~{layouts/app :: layout('Control Center', 'site', 'Cross-brewery visibility and admin shortcuts for the Mythic Tales network.', ~{::section[@id='page-content']})}">
 <section id="page-content">
   <section class="page-section">
     <div class="card-grid">

--- a/src/main/resources/templates/admin/taproom.html
+++ b/src/main/resources/templates/admin/taproom.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-      th:replace="layouts/app :: layout($ {'Taproom Operations · ' + (taproom != null ? taproom.name : 'Taproom')}, 'taproom', 'Operate taps, manage keg inventory, and track events for this taproom.', ~{::section[@id='page-content']})">
+      th:replace="~{layouts/app :: layout($ {'Taproom Operations · ' + (taproom != null ? taproom.name : 'Taproom')}, 'taproom', 'Operate taps, manage keg inventory, and track events for this taproom.', ~{::section[@id='page-content']})}">
 <section id="page-content">
   <section class="page-section">
     <div class="card-grid">

--- a/src/main/resources/templates/admin/users.html
+++ b/src/main/resources/templates/admin/users.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-      th:replace="layouts/app :: layout('User Access', 'users', 'Admin view of accounts, roles, and brewery affiliations.', ~{::section[@id='page-content']})">
+      th:replace="~{layouts/app :: layout('User Access', 'users', 'Admin view of accounts, roles, and brewery affiliations.', ~{::section[@id='page-content']})}">
 <section id="page-content">
   <section class="page-section">
     <div class="card-grid">

--- a/src/main/resources/templates/admin/venue.html
+++ b/src/main/resources/templates/admin/venue.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-      th:replace="layouts/app :: layout($ {'Venue Operations · ' + (venue != null ? venue.name : 'Venue')}, 'taproom', 'Monitor tap health and historical activity for this venue.', ~{::section[@id='page-content']})">
+      th:replace="~{layouts/app :: layout($ {'Venue Operations · ' + (venue != null ? venue.name : 'Venue')}, 'taproom', 'Monitor tap health and historical activity for this venue.', ~{::section[@id='page-content']})}">
 <section id="page-content">
   <section class="page-section">
     <div class="card-grid">


### PR DESCRIPTION
## Summary
- wrap every admin template layout include with ~{ } so Thymeleaf 3.1 stops warning and staging stops failing
- document the fix in review entry 20250919-thymeleaf-fragment-syntax.md

## Testing
- mvn -q -DskipTests compile
- manual: /admin/site renders without template parsing error