### PR TITLE
Guard admin/site template against missing address data

### DIFF
--- a/docs/tech/reviewbranches/20250919-site-template-guards.md
+++ b/docs/tech/reviewbranches/20250919-site-template-guards.md
@@ -1,0 +1,14 @@
+# feature/platform/site-template-guards
+
+- Area: platform
+- Owner: techlead
+- Task: docs/techtasks/000-technical-backlog.md (Thymeleaf hardening)
+- Summary: Guard admin/site template against missing Brewery address fields.
+- Scope: src/main/resources/templates/admin/site.html
+- Risk: low
+- Test Plan: `mvn -q -DskipTests compile` and hit /admin/site.
+- Status: in-progress
+- PR: <tbd>
+
+## Notes
+- Production data model for Brewery lacks address fields; template must render placeholders.

--- a/src/main/resources/templates/admin/site.html
+++ b/src/main/resources/templates/admin/site.html
@@ -60,18 +60,14 @@
       <thead>
         <tr>
           <th>Name</th>
-          <th>City</th>
-          <th>State</th>
         </tr>
       </thead>
       <tbody>
         <tr th:each="b : ${breweries}">
           <td th:text="${b.name}">Brewery Name</td>
-          <td th:text="${b.address != null ? b.address.city : '-'}">City</td>
-          <td th:text="${b.address != null ? b.address.state : '-'}">State</td>
         </tr>
         <tr th:if="${#lists.isEmpty(breweries)}">
-          <td colspan="3" class="muted">No breweries configured yet.</td>
+          <td class="muted">No breweries configured yet.</td>
         </tr>
       </tbody>
     </table>
@@ -90,13 +86,13 @@
       <thead>
         <tr>
           <th>Name</th>
-          <th>Location</th>
+          <th>Brewery</th>
         </tr>
       </thead>
       <tbody>
         <tr th:each="b : ${bars}">
           <td th:text="${b.name}">Bar Name</td>
-          <td th:text="${b.city != null ? b.city : '-'}">Location</td>
+          <td th:text="${b.brewery != null ? b.brewery.name : '-'}">Brewery</td>
         </tr>
         <tr th:if="${#lists.isEmpty(bars)}">
           <td colspan="2" class="muted">No bar partners on file.</td>


### PR DESCRIPTION
## Summary
- remove nonexistent brewery address bindings on /admin/site and show only the name column
- swap bar location column to display the owning brewery instead of a missing city field
- capture the fix in review entry 20250919-site-template-guards.md

## Testing
- mvn -q -DskipTests compile
- manual: /admin/site renders without SpEL errors