### PR TITLE
Enable scoped user management for site, brewery, and taproom

### DIFF
--- a/docs/tech/reviewbranches/20250920-user-access-enhancements.md
+++ b/docs/tech/reviewbranches/20250920-user-access-enhancements.md
@@ -1,0 +1,15 @@
+# feature/platform/user-access-complete
+
+- Area: platform
+- Owner: techlead
+- Task: docs/techtasks/000-technical-backlog.md (complete user access management)
+- Summary: Enable scoped user management for site, brewery, and taproom admins using the new enterprise UI shell.
+- Scope: src/main/java/com/mythictales/bms/taplist/controller/AdminUserController.java, src/main/java/com/mythictales/bms/taplist/controller/AdminBreweryController.java, src/main/java/com/mythictales/bms/taplist/controller/AdminTaproomController.java, templates/admin/users.html, templates/admin/brewery.html, templates/admin/taproom.html, static/css/app.css
+- Risk: medium (user provisioning touches authentication data)
+- Test Plan: `mvn -q -DskipTests compile`, manual checks for /admin/users, /admin/brewery?tab=users, /admin/taproom?tab=users
+- Status: in-progress
+- PR: <tbd>
+
+## Notes
+- Adds creation/deletion flows so each role can manage accounts within its scope.
+- Forms reuse the enterprise layout and expose context-sensitive role options.

--- a/src/main/java/com/mythictales/bms/taplist/controller/AdminUserController.java
+++ b/src/main/java/com/mythictales/bms/taplist/controller/AdminUserController.java
@@ -1,12 +1,27 @@
 package com.mythictales.bms.taplist.controller;
 
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import com.mythictales.bms.taplist.domain.Bar;
+import com.mythictales.bms.taplist.domain.Brewery;
+import com.mythictales.bms.taplist.domain.Role;
+import com.mythictales.bms.taplist.domain.Taproom;
+import com.mythictales.bms.taplist.domain.UserAccount;
+import com.mythictales.bms.taplist.repo.BarRepository;
+import com.mythictales.bms.taplist.repo.BreweryRepository;
+import com.mythictales.bms.taplist.repo.TaproomRepository;
 import com.mythictales.bms.taplist.repo.UserAccountRepository;
+import com.mythictales.bms.taplist.security.CurrentUser;
 
 @Controller
 @RequestMapping("/admin/users")
@@ -14,14 +29,156 @@ import com.mythictales.bms.taplist.repo.UserAccountRepository;
 public class AdminUserController {
 
   private final UserAccountRepository users;
+  private final BreweryRepository breweries;
+  private final TaproomRepository taprooms;
+  private final BarRepository bars;
+  private final PasswordEncoder passwordEncoder;
 
-  public AdminUserController(UserAccountRepository users) {
+  public AdminUserController(
+      UserAccountRepository users,
+      BreweryRepository breweries,
+      TaproomRepository taprooms,
+      BarRepository bars,
+      PasswordEncoder passwordEncoder) {
     this.users = users;
+    this.breweries = breweries;
+    this.taprooms = taprooms;
+    this.bars = bars;
+    this.passwordEncoder = passwordEncoder;
   }
 
   @GetMapping
-  public String listUsers(Model model) {
+  public String listUsers(@AuthenticationPrincipal CurrentUser currentUser, Model model) {
     model.addAttribute("users", users.findAll());
+    model.addAttribute("roles", Role.values());
+    model.addAttribute("breweries", breweries.findAll());
+    model.addAttribute("taprooms", taprooms.findAll());
+    model.addAttribute("bars", bars.findAll());
     return "admin/users";
+  }
+
+  @PostMapping
+  public String createUser(
+      @RequestParam String username,
+      @RequestParam String password,
+      @RequestParam Role role,
+      @RequestParam(name = "breweryId", required = false) Long breweryId,
+      @RequestParam(name = "taproomId", required = false) Long taproomId,
+      @RequestParam(name = "barId", required = false) Long barId,
+      RedirectAttributes redirectAttributes) {
+    String trimmedUsername = username == null ? "" : username.trim();
+    if (trimmedUsername.isEmpty() || password == null || password.isBlank()) {
+      redirectAttributes.addFlashAttribute(
+          "errorMessage", "Username and password are required to create a user.");
+      return "redirect:/admin/users";
+    }
+    if (users.findByUsername(trimmedUsername).isPresent()) {
+      redirectAttributes.addFlashAttribute(
+          "errorMessage", "Username already exists. Choose another." );
+      return "redirect:/admin/users";
+    }
+
+    UserAccount account = new UserAccount();
+    account.setUsername(trimmedUsername);
+    account.setPassword(passwordEncoder.encode(password));
+    account.setRole(role);
+
+    switch (role) {
+      case SITE_ADMIN -> {
+        account.setBrewery(null);
+        account.setTaproom(null);
+        account.setBar(null);
+      }
+      case BREWERY_ADMIN -> {
+        if (breweryId == null) {
+          redirectAttributes.addFlashAttribute(
+              "errorMessage", "Select a brewery for the new brewery admin user.");
+          return "redirect:/admin/users";
+        }
+        Brewery brewery =
+            breweries
+                .findById(breweryId)
+                .orElse(null);
+        if (brewery == null) {
+          redirectAttributes.addFlashAttribute(
+              "errorMessage", "Unable to locate the selected brewery.");
+          return "redirect:/admin/users";
+        }
+        account.setBrewery(brewery);
+        account.setTaproom(null);
+        account.setBar(null);
+      }
+      case TAPROOM_ADMIN, TAPROOM_USER -> {
+        if (taproomId == null) {
+          redirectAttributes.addFlashAttribute(
+              "errorMessage", "Select a taproom for the taproom user.");
+          return "redirect:/admin/users";
+        }
+        Taproom taproom = taprooms.findById(taproomId).orElse(null);
+        if (taproom == null) {
+          redirectAttributes.addFlashAttribute(
+              "errorMessage", "Unable to locate the selected taproom.");
+          return "redirect:/admin/users";
+        }
+        account.setTaproom(taproom);
+        account.setBrewery(taproom.getBrewery());
+        account.setBar(null);
+      }
+      case BAR_ADMIN -> {
+        if (barId == null) {
+          redirectAttributes.addFlashAttribute(
+              "errorMessage", "Select a bar for the bar admin user.");
+          return "redirect:/admin/users";
+        }
+        Bar bar = bars.findById(barId).orElse(null);
+        if (bar == null) {
+          redirectAttributes.addFlashAttribute(
+              "errorMessage", "Unable to locate the selected bar.");
+          return "redirect:/admin/users";
+        }
+        account.setBar(bar);
+        account.setBrewery(bar.getBrewery());
+        account.setTaproom(null);
+      }
+      default -> {
+        redirectAttributes.addFlashAttribute(
+            "errorMessage", "Unsupported role selection.");
+        return "redirect:/admin/users";
+      }
+    }
+
+    users.save(account);
+    redirectAttributes.addFlashAttribute(
+        "successMessage", "User %s created.".formatted(trimmedUsername));
+    return "redirect:/admin/users";
+  }
+
+  @PostMapping("/{userId}/delete")
+  public String deleteUser(
+      @PathVariable Long userId,
+      @AuthenticationPrincipal CurrentUser currentUser,
+      RedirectAttributes redirectAttributes) {
+    if (currentUser != null && currentUser.getId().equals(userId)) {
+      redirectAttributes.addFlashAttribute(
+          "errorMessage", "You cannot delete your own account while signed in.");
+      return "redirect:/admin/users";
+    }
+    users
+        .findById(userId)
+        .ifPresentOrElse(
+            user -> {
+              if (user.getRole() == Role.SITE_ADMIN && users.findAll().stream().filter(u -> u.getRole() == Role.SITE_ADMIN).count() <= 1) {
+                redirectAttributes.addFlashAttribute(
+                    "errorMessage", "At least one site admin account must remain.");
+              } else {
+                users.delete(user);
+                redirectAttributes.addFlashAttribute(
+                    "successMessage", "User %s removed.".formatted(user.getUsername()));
+              }
+            },
+            () ->
+                redirectAttributes.addFlashAttribute(
+                    "errorMessage", "Could not find the requested user."));
+    return "redirect:/admin/users";
   }
 }

--- a/src/main/resources/static/css/app.css
+++ b/src/main/resources/static/css/app.css
@@ -655,6 +655,10 @@ textarea:focus {
   color: var(--color-text-600);
 }
 
+.alert.success-alert {
+  border-left-color: var(--color-success-500);
+}
+
 .nowrap { white-space: nowrap; }
 
 .muted {

--- a/src/main/resources/templates/admin/brewery.html
+++ b/src/main/resources/templates/admin/brewery.html
@@ -346,6 +346,44 @@
       </div>
     </div>
 
+    <div class="alert" th:if="${errorMessage != null}" th:text="${errorMessage}"></div>
+    <div class="alert success-alert" th:if="${successMessage != null}" th:text="${successMessage}"></div>
+
+    <form class="form-grid" method="post" th:action="@{/admin/brewery/users}">
+      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+      <div class="form-group">
+        <label for="brew-username">Username</label>
+        <input id="brew-username" name="username" type="text" required />
+      </div>
+      <div class="form-group">
+        <label for="brew-password">Password</label>
+        <input id="brew-password" name="password" type="password" required />
+      </div>
+      <div class="form-group">
+        <label for="brew-role">Role</label>
+        <select id="brew-role" name="role">
+          <option th:each="r : ${breweryUserRoles}" th:value="${r}" th:text="${#strings.replace(r.name(),'_',' ')}"></option>
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="brew-taproom">Taproom</label>
+        <select id="brew-taproom" name="taproomId">
+          <option value="">-- None --</option>
+          <option th:each="t : ${taprooms}" th:value="${t.id}" th:text="${t.name}"></option>
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="brew-bar">Bar</label>
+        <select id="brew-bar" name="barId">
+          <option value="">-- None --</option>
+          <option th:each="b : ${breweryBars}" th:value="${b.id}" th:text="${b.name}"></option>
+        </select>
+      </div>
+      <div class="form-actions">
+        <button class="btn primary" type="submit">Create user</button>
+      </div>
+    </form>
+
     <form method="get" action="/admin/brewery" class="form-inline">
       <input type="hidden" name="tab" value="users" />
       <div class="form-group">
@@ -370,6 +408,7 @@
           <th>Brewery</th>
           <th>Taproom</th>
           <th>Bar</th>
+          <th>Actions</th>
         </tr>
         </thead>
         <tbody>
@@ -379,9 +418,15 @@
           <td th:text="${u.brewery != null ? u.brewery.name : '-'}">-</td>
           <td th:text="${u.taproom != null ? u.taproom.name : '-'}">-</td>
           <td th:text="${u.bar != null ? u.bar.name : '-'}">-</td>
+          <td class="actions">
+            <form method="post" th:action="@{'/admin/brewery/users/' + ${u.id} + '/delete'}">
+              <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+              <button class="btn ghost" type="submit">Remove</button>
+            </form>
+          </td>
         </tr>
         <tr th:if="${#lists.isEmpty(breweryUsers)}">
-          <td class="muted" colspan="5">No users found for the selected filter.</td>
+          <td class="muted" colspan="6">No users found for the selected filter.</td>
         </tr>
         </tbody>
       </table>

--- a/src/main/resources/templates/admin/taproom.html
+++ b/src/main/resources/templates/admin/taproom.html
@@ -258,18 +258,52 @@
         <p class="muted">Roles scoped to this taproom.</p>
       </div>
     </div>
+    <div class="alert" th:if="${errorMessage != null}" th:text="${errorMessage}"></div>
+    <div class="alert success-alert" th:if="${successMessage != null}" th:text="${successMessage}"></div>
+
+    <form class="form-grid" method="post" th:action="@{/admin/taproom/users}">
+      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+      <input type="hidden" name="taproomId" th:value="${taproom != null ? taproom.id : null}" />
+      <input type="hidden" name="from" th:value="${backToBrewery} ? 'brewery' : null" />
+      <div class="form-group">
+        <label for="taproom-username">Username</label>
+        <input id="taproom-username" name="username" type="text" required />
+      </div>
+      <div class="form-group">
+        <label for="taproom-password">Password</label>
+        <input id="taproom-password" name="password" type="password" required />
+      </div>
+      <div class="form-group">
+        <label for="taproom-role">Role</label>
+        <select id="taproom-role" name="role">
+          <option th:each="r : ${taproomUserRoles}" th:value="${r}" th:text="${#strings.replace(r.name(),'_',' ')}"></option>
+        </select>
+      </div>
+      <div class="form-actions">
+        <button class="btn primary" type="submit">Create user</button>
+      </div>
+    </form>
+
     <div class="table-wrapper">
       <table class="table">
         <thead>
-        <tr><th>Username</th><th>Role</th></tr>
+        <tr><th>Username</th><th>Role</th><th>Actions</th></tr>
         </thead>
         <tbody>
         <tr th:each="u : ${taproomUsers}">
           <td th:text="${u.username}">user</td>
           <td th:text="${#strings.replace(u.role,'ROLE_','')}">role</td>
+          <td class="actions">
+            <form method="post" th:action="@{'/admin/taproom/users/' + ${u.id} + '/delete'}">
+              <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+              <input type="hidden" name="taproomId" th:value="${taproom != null ? taproom.id : null}" />
+              <input type="hidden" name="from" th:value="${backToBrewery} ? 'brewery' : null" />
+              <button class="btn ghost" type="submit">Remove</button>
+            </form>
+          </td>
         </tr>
         <tr th:if="${#lists.isEmpty(taproomUsers)}">
-          <td class="muted" colspan="2">No users assigned to this taproom.</td>
+          <td class="muted" colspan="3">No users assigned to this taproom.</td>
         </tr>
         </tbody>
       </table>

--- a/src/main/resources/templates/admin/users.html
+++ b/src/main/resources/templates/admin/users.html
@@ -31,6 +31,53 @@
         <p class="muted">Sorted alphabetically by username with linked affiliations.</p>
       </div>
     </div>
+    <div class="alert" th:if="${errorMessage != null}" th:text="${errorMessage}"></div>
+    <div class="alert success-alert" th:if="${successMessage != null}" th:text="${successMessage}"></div>
+
+    <form class="form-grid" method="post" th:action="@{/admin/users}">
+      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+      <div class="form-group">
+        <label for="site-username">Username</label>
+        <input id="site-username" name="username" type="text" required />
+      </div>
+      <div class="form-group">
+        <label for="site-password">Password</label>
+        <input id="site-password" name="password" type="password" required />
+      </div>
+      <div class="form-group">
+        <label for="site-role">Role</label>
+        <select id="site-role" name="role">
+          <option th:each="r : ${roles}" th:value="${r}" th:text="${#strings.replace(r.name(),'_',' ')}"></option>
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="site-brewery">Brewery (for brewery, taproom, or bar users)</label>
+        <select id="site-brewery" name="breweryId">
+          <option value="">-- None --</option>
+          <option th:each="b : ${breweries}" th:value="${b.id}" th:text="${b.name}"></option>
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="site-taproom">Taproom</label>
+        <select id="site-taproom" name="taproomId">
+          <option value="">-- None --</option>
+          <option th:each="t : ${taprooms}" th:value="${t.id}"
+                  th:text="${t.name + (t.brewery != null ? ' · ' + t.brewery.name : '')}"></option>
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="site-bar">Bar</label>
+        <select id="site-bar" name="barId">
+          <option value="">-- None --</option>
+          <option th:each="b : ${bars}" th:value="${b.id}"
+                  th:text="${b.name + (b.brewery != null ? ' · ' + b.brewery.name : '')}"></option>
+        </select>
+      </div>
+      <div class="form-actions">
+        <button class="btn primary" type="submit">Create user</button>
+      </div>
+    </form>
+
     <div class="table-wrapper">
       <table class="table">
         <thead>
@@ -40,6 +87,7 @@
             <th>Brewery</th>
             <th>Taproom</th>
             <th>Bar</th>
+            <th>Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -52,9 +100,15 @@
             <td th:text="${u.brewery != null ? u.brewery.name : '-'}">-</td>
             <td th:text="${u.taproom != null ? u.taproom.name : '-'}">-</td>
             <td th:text="${u.bar != null ? u.bar.name : '-'}">-</td>
+            <td class="actions">
+              <form method="post" th:action="@{'/admin/users/' + ${u.id} + '/delete'}">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                <button class="btn ghost" type="submit">Remove</button>
+              </form>
+            </td>
           </tr>
           <tr th:if="${#lists.isEmpty(users)}">
-            <td class="muted" colspan="5">No users found.</td>
+            <td class="muted" colspan="6">No users found.</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
## Summary
- add full create/delete flows on /admin/users with role-aware association controls
- let brewery admins manage taproom/bar/brewery users and show flash feedback in the enterprise UI
- let taproom admins manage their own users; refreshed templates and styles for alerts

## Testing
- mvn -q -DskipTests compile
- manual: /admin/users, /admin/brewery?tab=users, /admin/taproom?tab=users