### PR TITLE
Route User Access menu to scoped management pages

### DIFF
--- a/docs/tech/reviewbranches/20250920-user-access-nav.md
+++ b/docs/tech/reviewbranches/20250920-user-access-nav.md
@@ -1,0 +1,14 @@
+# feature/platform/user-access-nav
+
+- Area: platform
+- Owner: techlead
+- Task: docs/techtasks/000-technical-backlog.md (user access navigation)
+- Summary: Point the User Access menu link to the context-specific user management page.
+- Scope: src/main/resources/templates/layouts/app.html
+- Risk: low
+- Test Plan: `mvn -q -DskipTests compile` and click User Access for site, brewery, and taproom roles.
+- Status: in-progress
+- PR: <tbd>
+
+## Notes
+- Site admins go to /admin/users, brewery admins to /admin/brewery?tab=users, taproom admins to /admin/taproom?tab=users.

--- a/src/main/resources/templates/layouts/app.html
+++ b/src/main/resources/templates/layouts/app.html
@@ -16,7 +16,13 @@
       <div class="nav-section">
         <p class="nav-label">Overview</p>
         <a th:href="@{/admin/site}" th:classappend="${activeSection} == 'site' ? ' active' : ''">Control Center</a>
-        <a th:href="@{/admin/users}" th:classappend="${activeSection} == 'users' ? ' active' : ''">User Access</a>
+        <a th:if="${currentUser != null and (currentUser.role == T(com.mythictales.bms.taplist.domain.Role).SITE_ADMIN
+                           or currentUser.role == T(com.mythictales.bms.taplist.domain.Role).BREWERY_ADMIN
+                           or currentUser.role == T(com.mythictales.bms.taplist.domain.Role).TAPROOM_ADMIN)}"
+           th:href="${currentUser.role == T(com.mythictales.bms.taplist.domain.Role).SITE_ADMIN} ? @{/admin/users} :
+                    (currentUser.role == T(com.mythictales.bms.taplist.domain.Role).BREWERY_ADMIN ? @{/admin/brewery(tab='users')} :
+                     @{/admin/taproom(tab='users')})"
+           th:classappend="${activeSection} == 'users' ? ' active' : ''">User Access</a>
       </div>
       <div class="nav-section">
         <p class="nav-label">Operations</p>


### PR DESCRIPTION
## Summary
- use the signed-in role to decide where the User Access nav link sends the user
- document the change in review entry 20250920-user-access-nav.md

## Testing
- mvn -q -DskipTests compile
- manual: click User Access as site, brewery, and taproom admins