### PR TITLE
Add BeerXML import workflow to admin recipes page

### DIFF
--- a/docs/tech/reviewbranches/20250919-recipe-import-ui.md
+++ b/docs/tech/reviewbranches/20250919-recipe-import-ui.md
@@ -1,0 +1,15 @@
+# feature/api/recipe-import-ui
+
+- Area: api
+- Owner: genie-catalog
+- Task: Add recipe import workflow to admin control center
+- Summary: Wire admin recipes page with BeerXML/BeerSmith import flow and display results
+- Scope: src/main/java/com/mythictales/bms/taplist/controller/AdminCatalogController.java; src/main/resources/templates/admin/catalog-recipes.html; src/test/java/com/mythictales/bms/taplist/controller/AdminCatalogControllerTest.java; docs/tech/reviewbranches/20250919-recipe-import-ui.md; src/main/resources/templates/admin/brewery.html (spotless)
+- Risk: medium
+- Test Plan: mvn -q verify; make check-format
+- Status: in-progress
+- PR: <tbd>
+
+## Notes
+- UI shows success/error flash messaging and optional overwrite toggle
+- Controller validates file size/type and delegates to RecipeImportService with flash responses

--- a/src/main/resources/templates/admin/brewery.html
+++ b/src/main/resources/templates/admin/brewery.html
@@ -191,7 +191,7 @@
                                   (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).DISTRIBUTED ? ' blue' :
                                   (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).RECEIVED ? ' purple' :
                                   (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).TAPPED ? ' orange' :
-                                  (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).BLOWN ? ' red' : ' gray'))))" 
+                                  (k.status == T(com.mythictales.bms.taplist.domain.KegStatus).BLOWN ? ' red' : ' gray'))))"
                   th:text="${k.status}">FILLED</span>
           </td>
           <td th:text="${k.assignedVenue != null ? k.assignedVenue.name : '-'}">-</td>

--- a/src/main/resources/templates/admin/catalog-recipes.html
+++ b/src/main/resources/templates/admin/catalog-recipes.html
@@ -18,6 +18,54 @@
   <section class="page-section">
     <div class="section-heading">
       <div>
+        <h2>Import recipes</h2>
+        <p class="muted">Upload BeerXML or BeerSmith XML to add to your library.</p>
+      </div>
+    </div>
+
+    <div class="alert" th:if="${importSuccessCount != null}">
+      <p>
+        <strong th:text="${'Imported ' + importSuccessCount + (importSuccessCount == 1 ? ' recipe.' : ' recipes.')}">
+          Imported 0 recipes.
+        </strong>
+      </p>
+      <p class="muted" th:if="${importForce}">Duplicates were overwritten during this import.</p>
+    </div>
+
+    <div class="alert" th:if="${importError != null}">
+      <p><strong>Import issue.</strong></p>
+      <p th:text="${importError}">Problem message.</p>
+      <p th:if="${importDuplicateId != null}">
+        Existing record:
+        <a th:href="@{'/admin/catalog/recipes/' + ${importDuplicateId}}">View recipe</a>.
+      </p>
+    </div>
+
+    <form method="post"
+          th:action="@{/admin/catalog/recipes/import}"
+          enctype="multipart/form-data"
+          class="form-grid">
+      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+      <div class="form-group">
+        <label for="recipeFile">Recipe file</label>
+        <input id="recipeFile" name="file" type="file" accept=".xml" required />
+        <p class="muted">Supports BeerXML or BeerSmith exports up to 2MB.</p>
+      </div>
+      <div class="form-group">
+        <label>Overwrite duplicates
+          <input type="checkbox" name="force" th:checked="${importForce}" />
+        </label>
+        <p class="muted">Skips duplicate checks and replaces matching recipes.</p>
+      </div>
+      <div class="form-actions">
+        <button class="btn primary" type="submit">Import recipes</button>
+      </div>
+    </form>
+  </section>
+
+  <section class="page-section">
+    <div class="section-heading">
+      <div>
         <h2>Recipe library</h2>
         <p class="muted">Search across brewery recipes and jump into detailed edits.</p>
       </div>

--- a/src/test/java/com/mythictales/bms/taplist/controller/AdminCatalogControllerTest.java
+++ b/src/test/java/com/mythictales/bms/taplist/controller/AdminCatalogControllerTest.java
@@ -1,34 +1,43 @@
 package com.mythictales.bms.taplist.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
 
 import com.mythictales.bms.taplist.catalog.domain.Recipe;
 import com.mythictales.bms.taplist.catalog.repo.RecipeRepository;
+import com.mythictales.bms.taplist.catalog.service.RecipeImportService;
+import com.mythictales.bms.taplist.catalog.service.RecipeImportService.DuplicateRecipeException;
+import com.mythictales.bms.taplist.domain.Brewery;
 
 /** Basic controller tests for recipe export and simple child add/remove flows. */
 public class AdminCatalogControllerTest {
 
   private RecipeRepository repo;
+  private RecipeImportService importer;
   private MockMvc mvc;
 
   @BeforeEach
   void setup() {
     repo = Mockito.mock(RecipeRepository.class);
+    importer = Mockito.mock(RecipeImportService.class);
     mvc =
-        MockMvcBuilders.standaloneSetup(new AdminCatalogController(repo))
+        MockMvcBuilders.standaloneSetup(new AdminCatalogController(repo, importer))
             .setCustomArgumentResolvers(
                 new org.springframework.security.web.method.annotation
                     .AuthenticationPrincipalArgumentResolver())
@@ -97,12 +106,69 @@ public class AdminCatalogControllerTest {
     verify(repo, times(1)).save(any());
   }
 
-  private org.springframework.security.core.userdetails.UserDetails dummyUser() {
+  @Test
+  void importRecipes_success_setsFlashAttributes() throws Exception {
+    AdminCatalogController controller = new AdminCatalogController(repo, importer);
+    MockMultipartFile file =
+        new MockMultipartFile(
+            "file",
+            "recipe.xml",
+            "application/xml",
+            "<RECIPES></RECIPES>".getBytes(StandardCharsets.UTF_8));
+    when(importer.importXml(eq(42L), anyString(), eq(false))).thenReturn(java.util.List.of(11L));
+
+    RedirectAttributesModelMap redirect = new RedirectAttributesModelMap();
+
+    String view = controller.importRecipes(dummyUser(), file, false, redirect);
+
+    org.junit.jupiter.api.Assertions.assertEquals("redirect:/admin/catalog/recipes", view);
+    org.junit.jupiter.api.Assertions.assertEquals(
+        1, redirect.getFlashAttributes().get("importSuccessCount"));
+    org.junit.jupiter.api.Assertions.assertEquals(
+        false, redirect.getFlashAttributes().get("importForce"));
+    verify(importer).importXml(eq(42L), anyString(), eq(false));
+  }
+
+  @Test
+  void importRecipes_duplicateSetsError() throws Exception {
+    AdminCatalogController controller = new AdminCatalogController(repo, importer);
+    MockMultipartFile file =
+        new MockMultipartFile(
+            "file", "recipe.xml", "application/xml", "<r/>".getBytes(StandardCharsets.UTF_8));
+
+    doThrow(new DuplicateRecipeException(7L))
+        .when(importer)
+        .importXml(eq(42L), anyString(), eq(false));
+
+    RedirectAttributesModelMap redirect = new RedirectAttributesModelMap();
+
+    String view = controller.importRecipes(dummyUser(), file, false, redirect);
+
+    org.junit.jupiter.api.Assertions.assertEquals("redirect:/admin/catalog/recipes", view);
+    org.junit.jupiter.api.Assertions.assertEquals(
+        7L, redirect.getFlashAttributes().get("importDuplicateId"));
+    org.junit.jupiter.api.Assertions.assertTrue(
+        redirect.getFlashAttributes().containsKey("importError"));
+    org.junit.jupiter.api.Assertions.assertEquals(
+        false, redirect.getFlashAttributes().get("importForce"));
+  }
+
+  private com.mythictales.bms.taplist.security.CurrentUser dummyUser() {
     com.mythictales.bms.taplist.domain.UserAccount ua =
         new com.mythictales.bms.taplist.domain.UserAccount(
             "tester", "pw", com.mythictales.bms.taplist.domain.Role.SITE_ADMIN);
+    Brewery brewery = new Brewery("Test Brewery");
+    try {
+      java.lang.reflect.Field bf = Brewery.class.getDeclaredField("id");
+      bf.setAccessible(true);
+      bf.set(brewery, 42L);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    ua.setBrewery(brewery);
     com.mythictales.bms.taplist.security.CurrentUser cu =
         new com.mythictales.bms.taplist.security.CurrentUser(ua);
+    org.junit.jupiter.api.Assertions.assertNotNull(cu.getBreweryId());
     return cu;
   }
 }


### PR DESCRIPTION
## Summary
- Add multipart recipe import handler to the admin control center so UI matches the new catalog requirements.
- Surface flash success/error messaging and overwrite toggle on the recipes page; record the review branch entry.
Branch entry: docs/tech/reviewbranches/20250919-recipe-import-ui.md

## Scope of changes

- Areas: api
- Key paths touched:
  - src/main/java/com/mythictales/bms/taplist/controller/AdminCatalogController.java
  - src/main/resources/templates/admin/catalog-recipes.html
  - src/test/java/com/mythictales/bms/taplist/controller/AdminCatalogControllerTest.java
  - docs/tech/reviewbranches/20250919-recipe-import-ui.md

## Validation

- [x] Built locally (`mvn verify`)
- [x] SpotBugs high-severity clean (`make spotbugs-strict`)
- [ ] Swagger UI loads (`/swagger-ui.html`)
- [ ] Manual test steps and results: _Not run in this pass; UI smoke test pending once catalog data available._

## Risks & Rollback Plan
- Import relies on RecipeImportService to parse XML; malformed files may still surface new edge cases. Roll back by reverting the controller/template/test changes.
- Flash messaging stores counts/error details in the session; if UI feedback misbehaves, revert commit 75ad934.
