### PR TITLE
Run Spotless formatting across taplist UI services

### DIFF
--- a/docs/tech/reviewbranches/20250919-spotless-cleanup.md
+++ b/docs/tech/reviewbranches/20250919-spotless-cleanup.md
@@ -1,0 +1,14 @@
+# feature/platform/spotless-cleanup
+
+- Area: platform
+- Owner: genie-catalog
+- Task: Resolve Spotless formatting drifts flagged in CI
+- Summary: Run repo-wide Spotless apply to bring controllers/templates back to policy
+- Scope: src/main/java/com/mythictales/bms/taplist/controller/AdminBarController.java; src/main/java/com/mythictales/bms/taplist/controller/AdminBreweryController.java; src/main/java/com/mythictales/bms/taplist/controller/AdminSiteController.java; src/main/java/com/mythictales/bms/taplist/controller/AdminTaproomController.java; src/main/java/com/mythictales/bms/taplist/controller/AdminUserController.java; src/main/java/com/mythictales/bms/taplist/controller/TaplistController.java; src/main/java/com/mythictales/bms/taplist/controller/UiPlaygroundController.java; src/main/java/com/mythictales/bms/taplist/domain/TaplistView.java; src/main/java/com/mythictales/bms/taplist/repo/TaplistViewRepository.java; src/main/java/com/mythictales/bms/taplist/service/TapService.java; src/main/java/com/mythictales/bms/taplist/service/TaplistProjectionUpdater.java
+- Risk: low
+- Test Plan: mvn -q spotless:apply; make check-format; mvn -q verify
+- Status: in-progress
+- PR: <tbd>
+
+## Notes
+- Automated formatting only; no behavior changes expected

--- a/src/main/java/com/mythictales/bms/taplist/controller/AdminBarController.java
+++ b/src/main/java/com/mythictales/bms/taplist/controller/AdminBarController.java
@@ -28,8 +28,7 @@ public class AdminBarController {
       tapList = taps.findByBarId(user.getBarId());
     }
 
-    long activeTaps =
-        tapList.stream().filter(t -> t.getKeg() != null).count();
+    long activeTaps = tapList.stream().filter(t -> t.getKeg() != null).count();
     long lowAlerts =
         tapList.stream()
             .filter(t -> t.getKeg() != null)

--- a/src/main/java/com/mythictales/bms/taplist/controller/AdminBreweryController.java
+++ b/src/main/java/com/mythictales/bms/taplist/controller/AdminBreweryController.java
@@ -11,15 +11,15 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import com.mythictales.bms.taplist.domain.Beer;
 import com.mythictales.bms.taplist.domain.Bar;
+import com.mythictales.bms.taplist.domain.Beer;
 import com.mythictales.bms.taplist.domain.Keg;
 import com.mythictales.bms.taplist.domain.KegSizeSpec;
 import com.mythictales.bms.taplist.domain.KegStatus;
 import com.mythictales.bms.taplist.domain.Role;
 import com.mythictales.bms.taplist.domain.UserAccount;
-import com.mythictales.bms.taplist.repo.BeerRepository;
 import com.mythictales.bms.taplist.repo.BarRepository;
+import com.mythictales.bms.taplist.repo.BeerRepository;
 import com.mythictales.bms.taplist.repo.BreweryRepository;
 import com.mythictales.bms.taplist.repo.KegRepository;
 import com.mythictales.bms.taplist.repo.KegSizeSpecRepository;
@@ -250,7 +250,8 @@ public class AdminBreweryController {
       model.addAttribute("breweryBars", java.util.List.of());
       model.addAttribute(
           "breweryUserRoles",
-          java.util.List.of(Role.BREWERY_ADMIN, Role.TAPROOM_ADMIN, Role.TAPROOM_USER, Role.BAR_ADMIN));
+          java.util.List.of(
+              Role.BREWERY_ADMIN, Role.TAPROOM_ADMIN, Role.TAPROOM_USER, Role.BAR_ADMIN));
       model.addAttribute("taproomCount", 0);
       model.addAttribute("activeTapHandles", 0);
       model.addAttribute("availableKegCount", 0);
@@ -293,14 +294,13 @@ public class AdminBreweryController {
     }
     if (users.findByUsername(trimmedUsername).isPresent()) {
       redirectAttributes.addFlashAttribute(
-          "errorMessage", "Username already exists. Choose another." );
+          "errorMessage", "Username already exists. Choose another.");
       return redirect;
     }
 
     var brewery = breweries.findById(breweryId).orElse(null);
     if (brewery == null) {
-      redirectAttributes.addFlashAttribute(
-          "errorMessage", "Unable to load brewery context.");
+      redirectAttributes.addFlashAttribute("errorMessage", "Unable to load brewery context.");
       return redirect;
     }
 
@@ -322,7 +322,9 @@ public class AdminBreweryController {
           return redirect;
         }
         var taproom = taprooms.findById(taproomId).orElse(null);
-        if (taproom == null || taproom.getBrewery() == null || !breweryId.equals(taproom.getBrewery().getId())) {
+        if (taproom == null
+            || taproom.getBrewery() == null
+            || !breweryId.equals(taproom.getBrewery().getId())) {
           redirectAttributes.addFlashAttribute(
               "errorMessage", "Taproom selection is not part of this brewery.");
           return redirect;
@@ -338,7 +340,9 @@ public class AdminBreweryController {
           return redirect;
         }
         Bar bar = bars.findById(barId).orElse(null);
-        if (bar == null || bar.getBrewery() == null || !breweryId.equals(bar.getBrewery().getId())) {
+        if (bar == null
+            || bar.getBrewery() == null
+            || !breweryId.equals(bar.getBrewery().getId())) {
           redirectAttributes.addFlashAttribute(
               "errorMessage", "Bar selection is not part of this brewery.");
           return redirect;
@@ -348,8 +352,7 @@ public class AdminBreweryController {
         account.setTaproom(null);
       }
       default -> {
-        redirectAttributes.addFlashAttribute(
-            "errorMessage", "Unsupported role selection.");
+        redirectAttributes.addFlashAttribute("errorMessage", "Unsupported role selection.");
         return redirect;
       }
     }

--- a/src/main/java/com/mythictales/bms/taplist/controller/AdminSiteController.java
+++ b/src/main/java/com/mythictales/bms/taplist/controller/AdminSiteController.java
@@ -37,10 +37,8 @@ public class AdminSiteController {
     model.addAttribute("breweryCount", breweries.count());
     model.addAttribute("barCount", bars.count());
     model.addAttribute("taproomCount", taprooms.count());
-    model.addAttribute(
-        "tappedKegCount", kegs.findByStatus(KegStatus.TAPPED).size());
-    model.addAttribute(
-        "distributedKegCount", kegs.findByStatus(KegStatus.DISTRIBUTED).size());
+    model.addAttribute("tappedKegCount", kegs.findByStatus(KegStatus.TAPPED).size());
+    model.addAttribute("distributedKegCount", kegs.findByStatus(KegStatus.DISTRIBUTED).size());
     return "admin/site";
   }
 }

--- a/src/main/java/com/mythictales/bms/taplist/controller/AdminTaproomController.java
+++ b/src/main/java/com/mythictales/bms/taplist/controller/AdminTaproomController.java
@@ -16,15 +16,15 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.mythictales.bms.taplist.domain.Beer;
-import com.mythictales.bms.taplist.domain.Role;
 import com.mythictales.bms.taplist.domain.KegEvent;
 import com.mythictales.bms.taplist.domain.KegSizeSpec;
 import com.mythictales.bms.taplist.domain.KegStatus;
+import com.mythictales.bms.taplist.domain.Role;
 import com.mythictales.bms.taplist.domain.Tap;
 import com.mythictales.bms.taplist.domain.Taproom;
+import com.mythictales.bms.taplist.domain.UserAccount;
 import com.mythictales.bms.taplist.domain.Venue;
 import com.mythictales.bms.taplist.domain.VenueType;
-import com.mythictales.bms.taplist.domain.UserAccount;
 import com.mythictales.bms.taplist.repo.BeerRepository;
 import com.mythictales.bms.taplist.repo.KegEventRepository;
 import com.mythictales.bms.taplist.repo.KegRepository;
@@ -257,8 +257,7 @@ public class AdminTaproomController {
 
     Taproom taproom = taprooms.findById(effectiveTaproomId).orElse(null);
     if (taproom == null) {
-      redirectAttributes.addFlashAttribute(
-          "errorMessage", "Taproom not found.");
+      redirectAttributes.addFlashAttribute("errorMessage", "Taproom not found.");
       return redirect;
     }
     if (currentUser != null
@@ -278,7 +277,7 @@ public class AdminTaproomController {
     }
     if (users.findByUsername(trimmedUsername).isPresent()) {
       redirectAttributes.addFlashAttribute(
-          "errorMessage", "Username already exists. Choose another." );
+          "errorMessage", "Username already exists. Choose another.");
       return redirect;
     }
 

--- a/src/main/java/com/mythictales/bms/taplist/controller/AdminUserController.java
+++ b/src/main/java/com/mythictales/bms/taplist/controller/AdminUserController.java
@@ -74,7 +74,7 @@ public class AdminUserController {
     }
     if (users.findByUsername(trimmedUsername).isPresent()) {
       redirectAttributes.addFlashAttribute(
-          "errorMessage", "Username already exists. Choose another." );
+          "errorMessage", "Username already exists. Choose another.");
       return "redirect:/admin/users";
     }
 
@@ -95,10 +95,7 @@ public class AdminUserController {
               "errorMessage", "Select a brewery for the new brewery admin user.");
           return "redirect:/admin/users";
         }
-        Brewery brewery =
-            breweries
-                .findById(breweryId)
-                .orElse(null);
+        Brewery brewery = breweries.findById(breweryId).orElse(null);
         if (brewery == null) {
           redirectAttributes.addFlashAttribute(
               "errorMessage", "Unable to locate the selected brewery.");
@@ -141,8 +138,7 @@ public class AdminUserController {
         account.setTaproom(null);
       }
       default -> {
-        redirectAttributes.addFlashAttribute(
-            "errorMessage", "Unsupported role selection.");
+        redirectAttributes.addFlashAttribute("errorMessage", "Unsupported role selection.");
         return "redirect:/admin/users";
       }
     }
@@ -167,7 +163,9 @@ public class AdminUserController {
         .findById(userId)
         .ifPresentOrElse(
             user -> {
-              if (user.getRole() == Role.SITE_ADMIN && users.findAll().stream().filter(u -> u.getRole() == Role.SITE_ADMIN).count() <= 1) {
+              if (user.getRole() == Role.SITE_ADMIN
+                  && users.findAll().stream().filter(u -> u.getRole() == Role.SITE_ADMIN).count()
+                      <= 1) {
                 redirectAttributes.addFlashAttribute(
                     "errorMessage", "At least one site admin account must remain.");
               } else {

--- a/src/main/java/com/mythictales/bms/taplist/controller/TaplistController.java
+++ b/src/main/java/com/mythictales/bms/taplist/controller/TaplistController.java
@@ -48,7 +48,8 @@ public class TaplistController {
       @RequestParam(value = "venueId", required = false) Long venueId,
       @RequestParam(value = "taproomId", required = false) Long taproomId,
       @RequestParam(value = "barId", required = false) Long barId,
-      @RequestParam(value = "refreshSeconds", required = false, defaultValue = "15") int refreshSeconds,
+      @RequestParam(value = "refreshSeconds", required = false, defaultValue = "15")
+          int refreshSeconds,
       Model model) {
     if (venueId != null) {
       model.addAttribute("projections", taplistViews.findByVenueIdOrderByTapIdAsc(venueId));

--- a/src/main/java/com/mythictales/bms/taplist/controller/UiPlaygroundController.java
+++ b/src/main/java/com/mythictales/bms/taplist/controller/UiPlaygroundController.java
@@ -2,6 +2,7 @@ package com.mythictales.bms.taplist.controller;
 
 import java.util.List;
 import java.util.Locale;
+
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -20,22 +21,10 @@ public class UiPlaygroundController {
               "foundations",
               "Foundations",
               "Color, typography, spacing tokens for the enterprise UI"),
-          new Story(
-              "buttons",
-              "Buttons",
-              "Primary, secondary, and ghost button treatments"),
-          new Story(
-              "cards",
-              "Cards",
-              "Metrics and content containers with headers and footers"),
-          new Story(
-              "tables",
-              "Tables",
-              "Data grid with zebra striping, badges, and bulk actions"),
-          new Story(
-              "forms",
-              "Forms",
-              "Input controls, validation states, and inline guidance"),
+          new Story("buttons", "Buttons", "Primary, secondary, and ghost button treatments"),
+          new Story("cards", "Cards", "Metrics and content containers with headers and footers"),
+          new Story("tables", "Tables", "Data grid with zebra striping, badges, and bulk actions"),
+          new Story("forms", "Forms", "Input controls, validation states, and inline guidance"),
           new Story(
               "overlays",
               "Overlays & Dialogs",
@@ -46,7 +35,8 @@ public class UiPlaygroundController {
               "Spark lines, tank capacity, and progress indicators"));
 
   @GetMapping
-  public String playground(@RequestParam(value = "story", required = false) String story, Model model) {
+  public String playground(
+      @RequestParam(value = "story", required = false) String story, Model model) {
     Story selected = selectStory(story);
     model.addAttribute("stories", STORIES);
     model.addAttribute("selectedStory", selected.id());
@@ -59,7 +49,10 @@ public class UiPlaygroundController {
       return STORIES.get(0);
     }
     String normalized = story.toLowerCase(Locale.ROOT);
-    return STORIES.stream().filter(s -> s.id().equals(normalized)).findFirst().orElse(STORIES.get(0));
+    return STORIES.stream()
+        .filter(s -> s.id().equals(normalized))
+        .findFirst()
+        .orElse(STORIES.get(0));
   }
 
   public record Story(String id, String label, String description) {}

--- a/src/main/java/com/mythictales/bms/taplist/domain/TaplistView.java
+++ b/src/main/java/com/mythictales/bms/taplist/domain/TaplistView.java
@@ -38,23 +38,75 @@ public class TaplistView {
     this.tapId = tapId;
   }
 
-  public Long getTapId() { return tapId; }
-  public void setTapId(Long tapId) { this.tapId = tapId; }
-  public Long getVenueId() { return venueId; }
-  public void setVenueId(Long venueId) { this.venueId = venueId; }
-  public String getBeerName() { return beerName; }
-  public void setBeerName(String beerName) { this.beerName = beerName; }
-  public String getStyle() { return style; }
-  public void setStyle(String style) { this.style = style; }
-  public Double getAbv() { return abv; }
-  public void setAbv(Double abv) { this.abv = abv; }
-  public Double getRemainingOunces() { return remainingOunces; }
-  public void setRemainingOunces(Double remainingOunces) { this.remainingOunces = remainingOunces; }
-  public Double getTotalOunces() { return totalOunces; }
-  public void setTotalOunces(Double totalOunces) { this.totalOunces = totalOunces; }
-  public Integer getFillPercent() { return fillPercent; }
-  public void setFillPercent(Integer fillPercent) { this.fillPercent = fillPercent; }
-  public Instant getUpdatedAt() { return updatedAt; }
-  public void setUpdatedAt(Instant updatedAt) { this.updatedAt = updatedAt; }
-}
+  public Long getTapId() {
+    return tapId;
+  }
 
+  public void setTapId(Long tapId) {
+    this.tapId = tapId;
+  }
+
+  public Long getVenueId() {
+    return venueId;
+  }
+
+  public void setVenueId(Long venueId) {
+    this.venueId = venueId;
+  }
+
+  public String getBeerName() {
+    return beerName;
+  }
+
+  public void setBeerName(String beerName) {
+    this.beerName = beerName;
+  }
+
+  public String getStyle() {
+    return style;
+  }
+
+  public void setStyle(String style) {
+    this.style = style;
+  }
+
+  public Double getAbv() {
+    return abv;
+  }
+
+  public void setAbv(Double abv) {
+    this.abv = abv;
+  }
+
+  public Double getRemainingOunces() {
+    return remainingOunces;
+  }
+
+  public void setRemainingOunces(Double remainingOunces) {
+    this.remainingOunces = remainingOunces;
+  }
+
+  public Double getTotalOunces() {
+    return totalOunces;
+  }
+
+  public void setTotalOunces(Double totalOunces) {
+    this.totalOunces = totalOunces;
+  }
+
+  public Integer getFillPercent() {
+    return fillPercent;
+  }
+
+  public void setFillPercent(Integer fillPercent) {
+    this.fillPercent = fillPercent;
+  }
+
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public void setUpdatedAt(Instant updatedAt) {
+    this.updatedAt = updatedAt;
+  }
+}

--- a/src/main/java/com/mythictales/bms/taplist/repo/TaplistViewRepository.java
+++ b/src/main/java/com/mythictales/bms/taplist/repo/TaplistViewRepository.java
@@ -9,4 +9,3 @@ import com.mythictales.bms.taplist.domain.TaplistView;
 public interface TaplistViewRepository extends JpaRepository<TaplistView, Long> {
   List<TaplistView> findByVenueIdOrderByTapIdAsc(Long venueId);
 }
-

--- a/src/main/java/com/mythictales/bms/taplist/service/TapService.java
+++ b/src/main/java/com/mythictales/bms/taplist/service/TapService.java
@@ -12,9 +12,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.mythictales.bms.taplist.domain.*;
-import com.mythictales.bms.taplist.repo.*;
 import com.mythictales.bms.taplist.kafka.DomainEventMetadata;
 import com.mythictales.bms.taplist.kafka.DomainEventPublisher;
+import com.mythictales.bms.taplist.repo.*;
 
 @Service
 public class TapService {

--- a/src/main/java/com/mythictales/bms/taplist/service/TaplistProjectionUpdater.java
+++ b/src/main/java/com/mythictales/bms/taplist/service/TaplistProjectionUpdater.java
@@ -23,19 +23,27 @@ public class TaplistProjectionUpdater {
 
   @EventListener
   @Transactional
-  public void onTapped(KegTapped evt) { refreshTap(evt.tapId()); }
+  public void onTapped(KegTapped evt) {
+    refreshTap(evt.tapId());
+  }
 
   @EventListener
   @Transactional
-  public void onPoured(BeerPoured evt) { refreshTap(evt.tapId()); }
+  public void onPoured(BeerPoured evt) {
+    refreshTap(evt.tapId());
+  }
 
   @EventListener
   @Transactional
-  public void onBlown(KegBlown evt) { refreshTap(evt.tapId()); }
+  public void onBlown(KegBlown evt) {
+    refreshTap(evt.tapId());
+  }
 
   @EventListener
   @Transactional
-  public void onUntapped(KegUntapped evt) { refreshTap(evt.tapId()); }
+  public void onUntapped(KegUntapped evt) {
+    refreshTap(evt.tapId());
+  }
 
   private void refreshTap(Long tapId) {
     Tap tap = taps.findById(tapId).orElse(null);
@@ -68,4 +76,3 @@ public class TaplistProjectionUpdater {
     viewRepo.save(v);
   }
 }
-


### PR DESCRIPTION
## Summary
- Run `mvn spotless:apply` to resolve the lingering formatting drifts flagged during recent builds.
- Bring taplist admin controllers, services, and view classes back to the enforced google-java-format baseline.
Branch entry: docs/tech/reviewbranches/20250919-spotless-cleanup.md

## Scope of changes

- Areas: platform
- Key paths touched:
  - src/main/java/com/mythictales/bms/taplist/controller/* (admin/taplist controllers)
  - src/main/java/com/mythictales/bms/taplist/service/* (tap services)
  - src/main/java/com/mythictales/bms/taplist/domain/TaplistView.java
  - src/main/java/com/mythictales/bms/taplist/repo/TaplistViewRepository.java

## Validation

- [x] Built locally (`mvn verify`)
- [x] SpotBugs high-severity clean (`make spotbugs-strict`)
- [ ] Swagger UI loads (`/swagger-ui.html`)
- [ ] Manual test steps and results: _Not applicable; no behavior changes._

## Risks & Rollback Plan
- Formatting-only change; minimal risk aside from potential merge conflicts with outstanding work. Roll back by reverting commit 07bb2c9.
