### PR TITLE
Support BeerSmith archive imports in catalog UI

### DIFF
--- a/docs/tech/reviewbranches/20250919-recipe-import-bsmx.md
+++ b/docs/tech/reviewbranches/20250919-recipe-import-bsmx.md
@@ -1,0 +1,14 @@
+# feature/api/recipe-import-bsmx
+
+- Area: api
+- Owner: genie-catalog
+- Task: Enable BeerSmith `.bsmx` uploads in the recipe import flow
+- Summary: Extend recipe import pipeline to accept BeerSmith archives and improve UI hints
+- Scope: src/main/java/com/mythictales/bms/taplist/catalog/service/RecipeImportService.java; src/main/java/com/mythictales/bms/taplist/catalog/api/RecipeImportController.java; src/main/java/com/mythictales/bms/taplist/controller/AdminCatalogController.java; src/main/resources/templates/admin/catalog-recipes.html; src/test/java/com/mythictales/bms/taplist/controller/AdminCatalogControllerTest.java; src/test/java/com/mythictales/bms/taplist/catalog/api/RecipeImportControllerTest.java
+- Risk: medium (new file handling path)
+- Test Plan: mvn -q verify; make check-format
+- Status: in-progress
+- PR: <tbd>
+
+## Notes
+- Adds Zip detection in RecipeImportService so both UI and API support BeerSmith `.bsmx`

--- a/src/main/java/com/mythictales/bms/taplist/catalog/api/RecipeImportController.java
+++ b/src/main/java/com/mythictales/bms/taplist/catalog/api/RecipeImportController.java
@@ -1,6 +1,5 @@
 package com.mythictales.bms.taplist.catalog.api;
 
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -81,12 +80,15 @@ public class RecipeImportController {
       if (ct != null
           && !(ct.equalsIgnoreCase(MediaType.APPLICATION_XML_VALUE)
               || ct.equalsIgnoreCase(MediaType.TEXT_XML_VALUE)
-              || ct.equalsIgnoreCase("application/octet-stream"))) {
+              || ct.equalsIgnoreCase(MediaType.APPLICATION_OCTET_STREAM_VALUE)
+              || ct.equalsIgnoreCase("application/zip")
+              || ct.equalsIgnoreCase("application/x-zip")
+              || ct.equalsIgnoreCase("application/x-zip-compressed"))) {
         throw new BusinessValidationException(
             "Unsupported content type", Map.of("contentType", ct));
       }
-      String xml = new String(file.getBytes(), StandardCharsets.UTF_8);
-      List<Long> ids = importer.importXml(breweryId, xml, force);
+      List<Long> ids =
+          importer.importFile(breweryId, file.getBytes(), file.getOriginalFilename(), force);
       return ResponseEntity.ok(new ImportResponse(ids));
     } catch (DuplicateRecipeException dup) {
       return ResponseEntity.status(HttpStatus.CONFLICT)

--- a/src/main/java/com/mythictales/bms/taplist/controller/AdminCatalogController.java
+++ b/src/main/java/com/mythictales/bms/taplist/controller/AdminCatalogController.java
@@ -97,15 +97,19 @@ public class AdminCatalogController {
     if (contentType != null
         && !(contentType.equalsIgnoreCase(MediaType.APPLICATION_XML_VALUE)
             || contentType.equalsIgnoreCase(MediaType.TEXT_XML_VALUE)
-            || contentType.equalsIgnoreCase(MediaType.APPLICATION_OCTET_STREAM_VALUE))) {
+            || contentType.equalsIgnoreCase(MediaType.APPLICATION_OCTET_STREAM_VALUE)
+            || contentType.equalsIgnoreCase("application/zip")
+            || contentType.equalsIgnoreCase("application/x-zip-compressed")
+            || contentType.equalsIgnoreCase("application/x-zip"))) {
       redirectAttributes.addFlashAttribute("importError", "Unsupported file type: " + contentType);
       redirectAttributes.addFlashAttribute("importForce", force);
       return "redirect:/admin/catalog/recipes";
     }
 
     try {
-      String xml = new String(file.getBytes(), StandardCharsets.UTF_8);
-      List<Long> ids = importer.importXml(user.getBreweryId(), xml, force);
+      List<Long> ids =
+          importer.importFile(
+              user.getBreweryId(), file.getBytes(), file.getOriginalFilename(), force);
       redirectAttributes.addFlashAttribute("importSuccessCount", ids.size());
       redirectAttributes.addFlashAttribute("importForce", force);
     } catch (DuplicateRecipeException dup) {

--- a/src/main/resources/templates/admin/catalog-recipes.html
+++ b/src/main/resources/templates/admin/catalog-recipes.html
@@ -48,8 +48,8 @@
       <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
       <div class="form-group">
         <label for="recipeFile">Recipe file</label>
-        <input id="recipeFile" name="file" type="file" accept=".xml" required />
-        <p class="muted">Supports BeerXML or BeerSmith exports up to 2MB.</p>
+        <input id="recipeFile" name="file" type="file" accept=".xml,.bsmx" required />
+        <p class="muted">Supports BeerXML (.xml) or BeerSmith (.bsmx) exports up to 2MB.</p>
       </div>
       <div class="form-group">
         <label>Overwrite duplicates

--- a/src/test/java/com/mythictales/bms/taplist/catalog/api/RecipeImportControllerTest.java
+++ b/src/test/java/com/mythictales/bms/taplist/catalog/api/RecipeImportControllerTest.java
@@ -1,12 +1,16 @@
 package com.mythictales.bms.taplist.catalog.api;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,7 +52,8 @@ public class RecipeImportControllerTest {
 
   @Test
   void ok_returnsIds() throws Exception {
-    when(service.importXml(eq(9L), any(String.class), eq(false))).thenReturn(List.of(1L, 2L));
+    when(service.importFile(eq(9L), any(byte[].class), any(), eq(false)))
+        .thenReturn(List.of(1L, 2L));
     MockMultipartFile f =
         new MockMultipartFile(
             "file",
@@ -67,7 +72,7 @@ public class RecipeImportControllerTest {
 
   @Test
   void duplicate_returns409() throws Exception {
-    when(service.importXml(eq(9L), any(String.class), eq(false)))
+    when(service.importFile(eq(9L), any(byte[].class), any(), eq(false)))
         .thenThrow(new RecipeImportService.DuplicateRecipeException(99L));
     MockMultipartFile f =
         new MockMultipartFile(
@@ -83,5 +88,34 @@ public class RecipeImportControllerTest {
                 .contentType(MediaType.MULTIPART_FORM_DATA))
         .andExpect(status().isConflict())
         .andExpect(content().contentType("application/problem+json"));
+  }
+
+  @Test
+  void beerSmithArchive_allowed() throws Exception {
+    when(service.importFile(eq(9L), any(byte[].class), any(), eq(true))).thenReturn(List.of(3L));
+    MockMultipartFile f =
+        new MockMultipartFile(
+            "file",
+            "beer.bsmx",
+            "application/x-zip-compressed",
+            zipBytes("recipes.xml", "<RECIPES><RECIPE/></RECIPES>"));
+    mvc.perform(
+            multipart("/api/v1/catalog/recipes/import")
+                .file(f)
+                .param("breweryId", "9")
+                .param("force", "true")
+                .contentType(MediaType.MULTIPART_FORM_DATA))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.ids[0]").value(3));
+  }
+
+  private static byte[] zipBytes(String name, String xml) throws Exception {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (ZipOutputStream zip = new ZipOutputStream(out)) {
+      zip.putNextEntry(new ZipEntry(name));
+      zip.write(xml.getBytes(StandardCharsets.UTF_8));
+      zip.closeEntry();
+    }
+    return out.toByteArray();
   }
 }

--- a/src/test/java/com/mythictales/bms/taplist/controller/AdminCatalogControllerTest.java
+++ b/src/test/java/com/mythictales/bms/taplist/controller/AdminCatalogControllerTest.java
@@ -1,14 +1,17 @@
 package com.mythictales.bms.taplist.controller;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -115,7 +118,8 @@ public class AdminCatalogControllerTest {
             "recipe.xml",
             "application/xml",
             "<RECIPES></RECIPES>".getBytes(StandardCharsets.UTF_8));
-    when(importer.importXml(eq(42L), anyString(), eq(false))).thenReturn(java.util.List.of(11L));
+    when(importer.importFile(eq(42L), any(byte[].class), any(), eq(false)))
+        .thenReturn(java.util.List.of(11L));
 
     RedirectAttributesModelMap redirect = new RedirectAttributesModelMap();
 
@@ -126,7 +130,7 @@ public class AdminCatalogControllerTest {
         1, redirect.getFlashAttributes().get("importSuccessCount"));
     org.junit.jupiter.api.Assertions.assertEquals(
         false, redirect.getFlashAttributes().get("importForce"));
-    verify(importer).importXml(eq(42L), anyString(), eq(false));
+    verify(importer).importFile(eq(42L), any(byte[].class), any(), eq(false));
   }
 
   @Test
@@ -138,7 +142,7 @@ public class AdminCatalogControllerTest {
 
     doThrow(new DuplicateRecipeException(7L))
         .when(importer)
-        .importXml(eq(42L), anyString(), eq(false));
+        .importFile(eq(42L), any(byte[].class), any(), eq(false));
 
     RedirectAttributesModelMap redirect = new RedirectAttributesModelMap();
 
@@ -151,6 +155,27 @@ public class AdminCatalogControllerTest {
         redirect.getFlashAttributes().containsKey("importError"));
     org.junit.jupiter.api.Assertions.assertEquals(
         false, redirect.getFlashAttributes().get("importForce"));
+  }
+
+  @Test
+  void importRecipes_acceptsBeerSmithArchive() throws Exception {
+    AdminCatalogController controller = new AdminCatalogController(repo, importer);
+    byte[] zipped = createZip("recipes.xml", "<RECIPES><RECIPE/></RECIPES>");
+    MockMultipartFile file =
+        new MockMultipartFile("file", "beer.bsmx", "application/x-zip-compressed", zipped);
+    when(importer.importFile(eq(42L), any(byte[].class), any(), eq(true)))
+        .thenReturn(java.util.List.of(21L));
+
+    RedirectAttributesModelMap redirect = new RedirectAttributesModelMap();
+
+    String view = controller.importRecipes(dummyUser(), file, true, redirect);
+
+    org.junit.jupiter.api.Assertions.assertEquals("redirect:/admin/catalog/recipes", view);
+    org.junit.jupiter.api.Assertions.assertEquals(
+        1, redirect.getFlashAttributes().get("importSuccessCount"));
+    org.junit.jupiter.api.Assertions.assertEquals(
+        true, redirect.getFlashAttributes().get("importForce"));
+    verify(importer).importFile(eq(42L), any(byte[].class), any(), eq(true));
   }
 
   private com.mythictales.bms.taplist.security.CurrentUser dummyUser() {
@@ -170,5 +195,15 @@ public class AdminCatalogControllerTest {
         new com.mythictales.bms.taplist.security.CurrentUser(ua);
     org.junit.jupiter.api.Assertions.assertNotNull(cu.getBreweryId());
     return cu;
+  }
+
+  private static byte[] createZip(String entryName, String contents) throws Exception {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (ZipOutputStream zos = new ZipOutputStream(out)) {
+      zos.putNextEntry(new ZipEntry(entryName));
+      zos.write(contents.getBytes(StandardCharsets.UTF_8));
+      zos.closeEntry();
+    }
+    return out.toByteArray();
   }
 }


### PR DESCRIPTION
## Summary
- Allow BeerSmith `.bsmx` archive uploads in the Control Center recipe import flow and mirror the support on the REST API.
- Add Zip/BOM handling in RecipeImportService and update tests plus UI hints accordingly.
Branch entry: docs/tech/reviewbranches/20250919-recipe-import-bsmx.md

## Scope of changes

- Areas: api
- Key paths touched:
  - src/main/java/com/mythictales/bms/taplist/catalog/service/RecipeImportService.java
  - src/main/java/com/mythictales/bms/taplist/catalog/api/RecipeImportController.java
  - src/main/java/com/mythictales/bms/taplist/controller/AdminCatalogController.java
  - src/main/resources/templates/admin/catalog-recipes.html
  - src/test/java/com/mythictales/bms/taplist/catalog/api/RecipeImportControllerTest.java
  - src/test/java/com/mythictales/bms/taplist/controller/AdminCatalogControllerTest.java

## Validation

- [x] Built locally (`mvn verify`)
- [x] SpotBugs high-severity clean (`make spotbugs-strict`)
- [ ] Swagger UI loads (`/swagger-ui.html`)
- [ ] Manual test steps and results: _Pending manual `.bsmx` upload smoke test._

## Risks & Rollback Plan
- Zip parsing assumes the first file entry is the BeerXML payload; malformed archives may still fail. Roll back by reverting commit d930b11 if import regressions arise.
- `importFile` is shared by UI and API; if issues surface, revert the controller/service changes together.
