### PR TITLE
Hide Catalog nav for site administrators

### DIFF
--- a/docs/tech/reviewbranches/20250920-hide-catalog-for-site.md
+++ b/docs/tech/reviewbranches/20250920-hide-catalog-for-site.md
@@ -1,0 +1,14 @@
+# feature/platform/hide-catalog-for-site
+
+- Area: platform
+- Owner: techlead
+- Task: docs/techtasks/000-technical-backlog.md (control center UX)
+- Summary: Hide the catalog navigation section for site administrators.
+- Scope: src/main/resources/templates/layouts/app.html
+- Risk: low
+- Test Plan: `mvn -q -DskipTests compile`, load /admin/site (no Catalog nav) and /admin/brewery (Catalog still visible).
+- Status: in-progress
+- PR: <tbd>
+
+## Notes
+- Site admins focus on control centers; catalog tools remain available for brewery/production roles.

--- a/src/main/resources/templates/layouts/app.html
+++ b/src/main/resources/templates/layouts/app.html
@@ -31,7 +31,7 @@
         <a th:href="@{/admin/taproom}" th:classappend="${activeSection} == 'taproom' ? ' active' : ''">Taprooms</a>
         <a th:href="@{/admin/bar}" th:classappend="${activeSection} == 'bar' ? ' active' : ''">Bars</a>
       </div>
-      <div class="nav-section">
+      <div class="nav-section" th:if="${currentUser == null || currentUser.role != T(com.mythictales.bms.taplist.domain.Role).SITE_ADMIN}">
         <p class="nav-label">Catalog</p>
         <a th:href="@{/admin/beer}" th:classappend="${activeSection} == 'beer' ? ' active' : ''">Beer Library</a>
         <a th:href="@{/admin/catalog/recipes}" th:classappend="${activeSection} == 'recipes' ? ' active' : ''">Recipes</a>


### PR DESCRIPTION
## Summary
- hide the Catalog navigation section when the signed-in user is a site admin
- document the change in docs/tech/reviewbranches/20250920-hide-catalog-for-site.md

## Testing
- mvn -q -DskipTests compile
- manual: /admin/site (no Catalog nav), /admin/brewery (Catalog nav visible)