### PR TITLE
Refresh domain landing pages with cards and lists

### DIFF
--- a/docs/tech/reviewbranches/20250920-brewery-control-center.md
+++ b/docs/tech/reviewbranches/20250920-brewery-control-center.md
@@ -12,4 +12,4 @@
 
 ## Notes
 - Cards now link to associated list pages; inline control menu replaces tab strips.
-- Default view shows only cards + brewery details; lists render when `tab` query is provided.
+- Default view now shows cards plus the taproom list; control menu links route to other lists via `tab` query.

--- a/src/main/resources/templates/admin/brewery.html
+++ b/src/main/resources/templates/admin/brewery.html
@@ -81,7 +81,7 @@
     </div>
   </section>
 
-  <section class="page-section" th:if="${tab == 'taprooms'}">
+    <section class="page-section" th:if="${tab == null or tab == 'taprooms'}">
     <div class="section-heading">
       <div>
         <h3>Taproom coverage</h3>

--- a/src/main/resources/templates/admin/users.html
+++ b/src/main/resources/templates/admin/users.html
@@ -1,7 +1,14 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-      th:replace="~{layouts/app :: layout('User Access', 'users', 'Admin view of accounts, roles, and brewery affiliations.', ~{::section[@id='page-content']})}">
+      th:replace="~{layouts/app :: layout('User Access Control Center', 'users', 'Admin view of accounts, roles, and brewery affiliations.', ~{::section[@id='page-content']})}">
 <section id="page-content">
+  <section class="page-section">
+    <div class="control-links">
+      <a class="control-link active" th:href="@{/admin/users}">Directory</a>
+      <a class="control-link" th:href="@{/admin/site}">Site Control Center</a>
+    </div>
+  </section>
+
   <section class="page-section">
     <div class="card-grid">
       <article class="metric-card">


### PR DESCRIPTION
## Summary
- show the taproom list alongside the metric cards on the brewery control center
- add a control link strip to the user access page so it follows the landing-page pattern
- update the brewery control center review notes to describe the new default view

## Testing
- mvn -q -DskipTests compile
- manual: /admin/brewery, /admin/users