### PR TITLE
Fix IAM modal CSRF handling

### DIFF
--- a/docs/tech/reviewbranches/20250922-iam-modal-csrf.md
+++ b/docs/tech/reviewbranches/20250922-iam-modal-csrf.md
@@ -1,0 +1,16 @@
+# feature/api/iam-modal-csrf
+
+- Area: api
+- Owner: genie-api
+- Task: <docs/techtasks/...>
+- Summary: Fix IAM create-user modal CSRF handling to avoid 403 responses.
+- Scope: src/main/resources/templates/admin/brewery.html
+- Risk: low
+- Test Plan:
+  - [ ] `mvn verify`
+  - [ ] Manual: Use IAM quick action modal to create a user without CSRF errors.
+- Status: proposed
+- PR: <tbd>
+
+## Notes
+- Ensures header/token pair comes from Spring and refreshes after POST requests.

--- a/src/main/resources/templates/admin/brewery.html
+++ b/src/main/resources/templates/admin/brewery.html
@@ -304,10 +304,17 @@
       }
 
       function resolveCsrfToken() {
+        const fromCookie = readCsrfToken();
+        if (fromCookie) {
+          if (consoleEl && consoleEl.dataset) {
+            consoleEl.dataset.csrfToken = fromCookie;
+          }
+          return fromCookie;
+        }
         if (consoleEl && consoleEl.dataset && consoleEl.dataset.csrfToken) {
           return consoleEl.dataset.csrfToken;
         }
-        return readCsrfToken();
+        return null;
       }
       /*]]>*/
     </script>

--- a/src/main/resources/templates/admin/brewery.html
+++ b/src/main/resources/templates/admin/brewery.html
@@ -8,7 +8,9 @@
         th:attr="data-overrides=${consoleDataJson},
                   data-selected-domain=${consoleSelectedDomain},
                   data-brewery-id=${brewery != null ? brewery.id : ''},
-                  data-brewery-name=${brewery != null ? brewery.name : 'Brewery'}"></mt-enterprise-console>
+                  data-brewery-name=${brewery != null ? brewery.name : 'Brewery'},
+                  data-csrf-token=${_csrf != null ? _csrf.token : ''},
+                  data-csrf-header=${_csrf != null ? _csrf.headerName : ''}"></mt-enterprise-console>
     <script th:inline="javascript">
       /*<![CDATA[*/
       (function () {
@@ -20,6 +22,7 @@
         const selectedDomainRaw = consoleEl.dataset.selectedDomain || '';
         const breweryIdValue = consoleEl.dataset.breweryId || '';
         const breweryName = consoleEl.dataset.breweryName || 'Brewery';
+        const csrfHeaderName = consoleEl.dataset.csrfHeader || 'X-XSRF-TOKEN';
 
         const venuesCache = { list: null, loading: false };
         const queueSize = 6;
@@ -275,6 +278,13 @@
           },
           credentials: 'same-origin'
         };
+        const csrfToken = resolveCsrfToken();
+        if (csrfToken) {
+          options.headers[csrfHeaderName] = csrfToken;
+          if (csrfHeaderName !== 'X-XSRF-TOKEN') {
+            options.headers['X-XSRF-TOKEN'] = csrfToken;
+          }
+        }
         if (body && Object.keys(body).length > 0) {
           options.body = JSON.stringify(body);
         }
@@ -282,10 +292,22 @@
         if (!response.ok) {
           throw new Error(`Request failed (${response.status})`);
         }
-        return response
+        const result = await response
           .text()
           .then((text) => (text ? JSON.parse(text) : {}))
           .catch(() => ({}));
+        const latestToken = readCsrfToken();
+        if (latestToken && consoleEl && consoleEl.dataset) {
+          consoleEl.dataset.csrfToken = latestToken;
+        }
+        return result;
+      }
+
+      function resolveCsrfToken() {
+        if (consoleEl && consoleEl.dataset && consoleEl.dataset.csrfToken) {
+          return consoleEl.dataset.csrfToken;
+        }
+        return readCsrfToken();
       }
       /*]]>*/
     </script>


### PR DESCRIPTION
## Summary

Fix CSRF handling for the IAM enterprise console modal so create-user POSTs send the Spring-issued token/header pair.

Branch entry: docs/tech/reviewbranches/20250922-iam-modal-csrf.md

## Scope of changes

- Areas: api
- Key paths touched:
  - src/main/resources/templates/admin/brewery.html

## Validation

- [ ] Built locally (`mvn verify`)
- [ ] SpotBugs high-severity clean
- [ ] Swagger UI loads (`/swagger-ui.html`)
- [ ] Manual test steps and results:
  - Pending: attempt IAM modal create-user to confirm no CSRF 403.

## Risks & Rollback Plan

Touches shared postJson helper used by other console quick actions; rollback via `git revert 7e893d1` if regressions surface.
