### PR TITLE
Fix IAM consoleEl reference errors

### DIFF
--- a/docs/tech/reviewbranches/20250922-iam-console-global.md
+++ b/docs/tech/reviewbranches/20250922-iam-console-global.md
@@ -1,0 +1,16 @@
+# feature/api/iam-console-global
+
+- Area: api
+- Owner: genie-api
+- Task: <docs/techtasks/...>
+- Summary: Make IAM console globals safe for CSRF/token refresh helpers to avoid ReferenceErrors.
+- Scope: src/main/resources/templates/admin/brewery.html
+- Risk: low
+- Test Plan:
+  - [ ] `mvn verify`
+  - [ ] Manual: Open IAM quick actions (assign, create user) and confirm no console errors.
+- Status: proposed
+- PR: <tbd>
+
+## Notes
+- Exposes console & caches as globals shared by helper functions defined outside the setup IIFE.

--- a/src/main/resources/templates/admin/brewery.html
+++ b/src/main/resources/templates/admin/brewery.html
@@ -50,8 +50,12 @@
     </dialog>
     <script th:inline="javascript">
       /*<![CDATA[*/
+      const consoleEl = document.getElementById('brewConsole');
+      const venuesCache = { list: null, loading: false };
+      const queueSize = 6;
+      const activitySize = 5;
+
       (function () {
-        const consoleEl = document.getElementById('brewConsole');
         if (!consoleEl) {
           return;
         }
@@ -83,10 +87,6 @@
             }
           });
         }
-
-        const venuesCache = { list: null, loading: false };
-        const queueSize = 6;
-        const activitySize = 5;
 
         customElements
           .whenDefined('mt-enterprise-console')


### PR DESCRIPTION
## Summary

Share the enterprise console element and helper caches at script scope so quick action helpers can access them without ReferenceErrors.

Branch entry: docs/tech/reviewbranches/20250922-iam-console-global.md

## Scope of changes

- Areas: api
- Key paths touched:
  - src/main/resources/templates/admin/brewery.html

## Validation

- [ ] Built locally (`mvn verify`)
- [ ] SpotBugs high-severity clean
- [ ] Swagger UI loads (`/swagger-ui.html`)
- [ ] Manual test steps and results:
  - Pending: exercise IAM quick actions (assign, create user) and confirm no `consoleEl` ReferenceError in Safari.

## Risks & Rollback Plan

Low risk (script-only). Roll back via `git revert 3b9b78c` if unexpected side effects surface.
