### PR TITLE
Add PageImpl diagnostics for IAM users

### DIFF
--- a/docs/tech/reviewbranches/20250922-iam-csrf-debug.md
+++ b/docs/tech/reviewbranches/20250922-iam-csrf-debug.md
@@ -1,0 +1,16 @@
+# feature/api/iam-csrf-debug
+
+- Area: api
+- Owner: genie-api
+- Task: <docs/techtasks/...>
+- Summary: Add diagnostics for PageImpl warnings and CSRF fetch flow.
+- Scope: src/main/java/com/mythictales/bms/taplist/api/UserApiController.java
+- Risk: low
+- Test Plan:
+  - [ ] `mvn verify`
+  - [ ] Manual: Reproduce IAM API calls and inspect logs for new debug/warn output.
+- Status: proposed
+- PR: <tbd>
+
+## Notes
+- Logging will help pinpoint why PageImpl serialization occurs.


### PR DESCRIPTION
## Summary

Add targeted logging around IAM user pagination to understand the PageImpl serialization warning and log pageable details.

Branch entry: docs/tech/reviewbranches/20250922-iam-csrf-debug.md

## Scope of changes

- Areas: api
- Key paths touched:
  - src/main/java/com/mythictales/bms/taplist/api/UserApiController.java

## Validation

- [ ] Built locally (`mvn verify`)
- [ ] SpotBugs high-severity clean
- [ ] Swagger UI loads (`/swagger-ui.html`)
- [ ] Manual test steps and results:
  - Pending: trigger IAM user list endpoint and inspect logs for new diagnostics.

## Risks & Rollback Plan

Log-only change; revert via `git revert 2643a1a` if noise is excessive.
