### PR TITLE
Add IAM CSRF client debug logging

### DIFF
--- a/docs/tech/reviewbranches/20250922-iam-csrf-debug-client.md
+++ b/docs/tech/reviewbranches/20250922-iam-csrf-debug-client.md
@@ -1,0 +1,15 @@
+# feature/api/iam-csrf-debug-client
+
+- Area: api
+- Owner: genie-api
+- Task: <docs/techtasks/...>
+- Summary: Emit client-side diagnostics for CSRF token/header behavior in IAM console.
+- Scope: src/main/resources/templates/admin/brewery.html
+- Risk: low
+- Test Plan:
+  - [ ] Reproduce IAM modal POST; inspect browser console for debug logs.
+- Status: proposed
+- PR: <tbd>
+
+## Notes
+- Aids debugging persistent 403 by logging tokens and response headers.

--- a/src/main/resources/templates/admin/brewery.html
+++ b/src/main/resources/templates/admin/brewery.html
@@ -573,6 +573,15 @@
           credentials: 'same-origin'
         };
         const csrfToken = resolveCsrfToken();
+        if (consoleEl) {
+          console.debug('IAM csrf debug: preparing request', {
+            url,
+            headerName: csrfHeaderName,
+            datasetToken: consoleEl.dataset ? consoleEl.dataset.csrfToken : null,
+            cookieToken: csrfToken,
+            headers: options.headers
+          });
+        }
         if (csrfToken) {
           options.headers[csrfHeaderName] = csrfToken;
           if (csrfHeaderName !== 'X-XSRF-TOKEN') {
@@ -584,6 +593,13 @@
         }
         const response = await fetch(url, options);
         if (!response.ok) {
+          if (consoleEl) {
+            console.warn('IAM csrf debug: non-OK response', {
+              status: response.status,
+              statusText: response.statusText,
+              headers: Object.fromEntries(response.headers.entries())
+            });
+          }
           throw new Error(`Request failed (${response.status})`);
         }
         const result = await response


### PR DESCRIPTION
## Summary

Add client-side logging so we can inspect CSRF tokens/headers before IAM modal POSTs and capture response metadata on failures.

Branch entry: docs/tech/reviewbranches/20250922-iam-csrf-debug-client.md

## Scope of changes

- Areas: api
- Key paths touched:
  - src/main/resources/templates/admin/brewery.html

## Validation

- [ ] Built locally (`mvn verify`)
- [ ] SpotBugs high-severity clean
- [ ] Swagger UI loads
- [ ] Manual test steps and results:
  - Pending: trigger IAM modal POST in Safari; inspect console for new debug output.

## Risks & Rollback Plan

Console noise only; roll back via `git revert 40a858b` when investigation ends.
